### PR TITLE
Fix issue #43.

### DIFF
--- a/exchanges/btce.js
+++ b/exchanges/btce.js
@@ -40,7 +40,7 @@ Trader.prototype.sell = function(amount, price, callback) {
   // Prevent "You incorrectly entered one of fields."
   // because of more than 8 decimals.
   amount *= 100000000;
-  amount = Math.ceil(amount);
+  amount = Math.floor(amount);
   amount /= 100000000;
 
   var set = function(err, data) {


### PR DESCRIPTION
When checking for available balance we should use floor.
Here is an example of the problem: 
:~$ nodejs
amount = 4.55239783;
4.55239783
amount *= 100000000;
455239783.00000006
amount = Math.ceil(amount);
455239784
amount /= 100000000;
4.55239784

As you can see the value is incorrectly rounded and you actually try to sell more than you have on the next step. 
