### PR TITLE
refresh portfolio stats every 11 minutes

### DIFF
--- a/portfolioManager.js
+++ b/portfolioManager.js
@@ -54,16 +54,24 @@ var Manager = function(conf, checker) {
     this.emit('ready');
   };
 
-  // callback function to refresh portfolio stats
-  var refreshPortfolio = function() {
+  // callback function to DISPLAY portfolio stats
+  var refreshPortfolioBeforeYouCanDisplay = function() {
     log.info('refreshed', this.exchange.name, 'portfolio:');
     _.each(this.portfolio, function(fund) {
       log.info('\t', fund.name + ':', fund.amount);
     });
   };
 
-  // refresh portfolio stats every 11 minutes
-  setInterval(_.bind(refreshPortfolio, this), util.minToMs( 11 ));
+  // callback function to REFRESH portfolio stats
+  var displayPortfolio = function() {
+	  // lazy way to do it without a major rewrite
+	  async.series([
+	                this.setPortfolio
+	                ], _.bind(refreshPortfolioBeforeYouCanDisplay, this));
+  };
+
+  // refresh and display portfolio stats every 11 minutes
+  setInterval(_.bind(displayPortfolio, this), util.minToMs( 11 ));
 
   async.series([
     this.setPortfolio,


### PR DESCRIPTION
some users would prefer the cex.io portfolio balance should be refreshed periodically with more current BTC balance (as a result of BTC withdraw, deposit, mining new coin with the GHS, etc.)

this commit will affect all exchanges, not just cex.io

refresh period is 11 minutes
