### PR TITLE
Refresh & log updated portfolio balance so that advice & trading is not based on old data

### DIFF
--- a/portfolioManager.js
+++ b/portfolioManager.js
@@ -54,16 +54,24 @@ var Manager = function(conf, checker) {
     this.emit('ready');
   };
 
-  // callback function to refresh portfolio stats
-  var refreshPortfolio = function() {
+  // callback function to DISPLAY portfolio stats
+  var refreshPortfolioBeforeYouCanDisplay = function() {
     log.info('refreshed', this.exchange.name, 'portfolio:');
     _.each(this.portfolio, function(fund) {
       log.info('\t', fund.name + ':', fund.amount);
     });
   };
 
-  // refresh portfolio stats every 11 minutes
-  setInterval(_.bind(refreshPortfolio, this), util.minToMs( 11 ));
+  // callback function to REFRESH portfolio stats
+  var displayPortfolio = function() {
+	  // lazy way to do it without a major rewrite
+	  async.series([
+	                this.setPortfolio
+	                ], _.bind(refreshPortfolioBeforeYouCanDisplay, this));
+  };
+
+  // refresh and display portfolio stats every 11 minutes
+  setInterval(_.bind(displayPortfolio, this), util.minToMs( 11 ));
 
   async.series([
     this.setPortfolio,


### PR DESCRIPTION
This time a "refresh-balance" branch was created on my own repository unlike #65 and #66 which were NOT properly insulated from any work I was doing on my own fork unrelated to this patch for keeping the portfolio state more consistent with realtime balance on the exchanges.
