### PR TITLE
Make profit reporting working again

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -91,9 +91,9 @@ Logger.prototype.trackProfits = function(what, price, meta) {
   if(this.tracks === 1)
     return;
 
-  if(!this.verbose && what === 'SELL' && !this.config.backtest)
+  if(!this.verbose && what === 'SELL' && !this.config.backtest.enabled)
     this.report();
-  else if(this.verbose && !this.config.backtest)
+  else if(this.verbose && !this.config.backtest.enabled)
     this.report();
 }
 


### PR DESCRIPTION
Currently profit reporting is not working because there is "config.backtest" section in config.js.

gekko-backtest.js enables backtest mode using line "config.backtest.enabled = true;" so we need check config.backtest.enabled variable in logger.js.
