### PR TITLE
Skip first treshold on start

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,7 +22,9 @@ config.EMA = {
   candles: 100,
   // the difference between the EMAs (to act as triggers)
   sellTreshold: -0.25,
-  buyTreshold: 0.25
+  buyTreshold: 0.25,
+  // Don't buy if we are already too late
+  neverBuyAbove: 0.5
 };
 
 // Monitor the live market

--- a/methods/exponential-moving-averages.js
+++ b/methods/exponential-moving-averages.js
@@ -158,7 +158,11 @@ TradingMethod.prototype.advice = function() {
 
     if(this.currentTrend !== 'up') {
       this.currentTrend = 'up';
-      this.emit('advice', 'BUY', price, message);
+      if (diff > settings.neverBuyAbove) {
+       log.debug("We are already too late so we don't buy anymore");
+       this.emit('advice', 'HOLD', price, message);
+      } else
+       this.emit('advice', 'BUY', price, message);
     } else
       this.emit('advice', 'HOLD', price, message);
 


### PR DESCRIPTION
When gekko starts it want always immediately BUY or SELL because it not have any value in "this.currentTrend" variable.

This fix makes gekko always skip first treshold and wait that trend really changes.
