### PR TITLE
Fixed issue with email password in configuration not being honored

### DIFF
--- a/actors/mailer.js
+++ b/actors/mailer.js
@@ -46,7 +46,7 @@ Mailer.prototype.setup = function(done) {
           this.done();
         }, this)
       );
-    } else 
+    } else
       this.done();
 
     log.debug('Setup email adviser.');
@@ -67,7 +67,7 @@ Mailer.prototype.setup = function(done) {
     log.warn(warning);
     prompt.get({name: 'password', hidden: true}, _.bind(setupMail, this));
   } else {
-    setupMail(null, mailConfig.password);
+    setupMail(null, {password: mailConfig.password});
   }
 }
 


### PR DESCRIPTION
The password in the mailer configuration was being ignored causing
problems when running gekko using screen (where you'd have to re-attach
the session to enter the password manually).
