### PR TITLE
Properly set the scope of the setupMail function

### DIFF
--- a/actors/mailer.js
+++ b/actors/mailer.js
@@ -67,7 +67,7 @@ Mailer.prototype.setup = function(done) {
     log.warn(warning);
     prompt.get({name: 'password', hidden: true}, _.bind(setupMail, this));
   } else {
-    setupMail.call(this, null, {password: mailConfig.password});
+    setupMail.call(this, false, false);
   }
 }
 


### PR DESCRIPTION
When passing password from configuration, the scope of the setupMail function was wrong causing this.mail call on line 33 to crash.
