### PR TITLE
Add Campfire bot plugin

### DIFF
--- a/config.js
+++ b/config.js
@@ -163,6 +163,15 @@ config.ircbot = {
   botName: 'gekkobot'
 }
 
+config.campfire = {
+  enabled: false,
+  emitUpdates: false,
+  nickname: 'Gordon',
+  roomId: null,
+  apiKey: '',
+  account: ''
+}
+
 config.redisBeacon = {
   enabled: false,
   port: 6379, // redis default

--- a/plugins.js
+++ b/plugins.js
@@ -52,6 +52,18 @@ var actors = [
     }]
   },
   {
+    name: 'Campfire bot',
+    description: 'Campfire module lets you communicate with Gekko on Campfire.',
+    slug: 'campfire',
+    async: false,
+    silent: false,
+    modes: ['realtime'],
+    dependencies: [{
+      module: 'ranger',
+      version: '0.2.4'
+    }]
+  },
+  {
     name: 'Mailer',
     description: 'Mail module lets sends you email yourself everytime Gekko has new advice.',
     slug: 'mailer',

--- a/plugins/campfire.js
+++ b/plugins/campfire.js
@@ -1,0 +1,114 @@
+var _ = require('lodash');
+var Moment = require('moment');
+var Ranger = require('ranger');
+
+var config = require('../core/util').getConfig().campfire;
+
+var Actor = function() {
+  _.bindAll(this);
+
+  this.commands = [{
+    'handler': 'advice',
+    'callback': this.sayAdvice,
+    'description': "Advice on what position to take, depending on the current trend"
+  }, {
+    'handler': 'price',
+    'callback': this.sayPrice,
+    'description': "The current price of the asset in the configured currency"
+  }, {
+    'handler': 'donate',
+    'callback': this.sayDonate,
+    'description': "Where to send all of that extra coin that's weighing you down"
+  }, {
+    'handler': 'help',
+    'callback': this.sayHelp,
+    'description': "You are here"
+  }];
+
+  this.advice = null;
+  this.adviceTime = Moment.utc();
+  this.price = null;
+  this.priceTime = Moment.utc();
+
+  this.client = Ranger.createClient(config.account, config.apiKey);
+  this.client.room(config.roomId, this.joinRoom);
+};
+
+Actor.prototype = {
+  processTrade: function(trade) {
+    this.price = trade.price;
+    this.priceTime = Moment.unix(trade.date);
+  },
+
+  processAdvice: function(advice) {
+    this.advice = advice.recommandation;
+    this.adviceTime = Moment.utc();
+
+    if (config.emitUpdates) {
+      this.sayAdvice();
+    }
+  },
+
+  sayAdvice: function() {
+    var message;
+
+    if (this.advice !== null) {
+      message = ["We think you should", this.advice + ".", "(" + this.adviceTime.fromNow() + ")"];
+    } else {
+      message = ["We don't have any advice for you quite yet."];
+    }
+
+    this.room.speak(message.join(' '));
+  },
+
+  sayPrice: function() {
+    var message;
+
+    if (this.price !== null) {
+      message = ["The price at the moment is", this.price + ".", "(" + this.priceTime.fromNow() + ")"];
+    } else {
+      message = ["We don't know the price right now."];
+    }
+
+    this.room.speak(message.join(' '));
+  },
+
+  sayDonation: function() {
+    this.room.speak("If you'd like to donate a few coins, you can send them here: 13r1jyivitShUiv9FJvjLH7Nh1ZZptumwW");
+  },
+
+  sayHelp: function() {
+    this.room.speak("I listen for the following inquiries...", this.pasteDescriptions);
+  },
+
+  pasteDescriptions: function() {
+    var descriptions = _.map(this.commands, function(command) {
+      return [command.handler + ':', command.description].join(' ');
+    }, this).join('\n');
+
+    this.room.paste(descriptions);
+  },
+
+  joinRoom: function(room) {
+    this.room = room;
+    this.room.join(this.listenForCommands);
+  },
+
+  listenForCommands: function() {
+    this.room.listen(this.executeCommands);
+  },
+
+  executeCommands: function(message) {
+    var nickname = new RegExp(config.nickname, 'i'), handler;
+
+    _.each(this.commands, function(command) {
+      handler = new RegExp(command.handler, 'i');
+
+      if (message.body.match(nickname) && message.body.match(handler)) {
+        command.callback();
+      }
+    }, this);
+  }
+};
+
+module.exports = Actor;


### PR DESCRIPTION
I've been playing with Gekko a lot over the last few days and had some time to spare tonight, so I figured it might be worth slapping together a [Campfire](https://campfirenow.com/) plugin for it to exercise my Node chops.

For now, the advice that it gives is just the standard "go short", "go long", or "hold" spiel because I felt like all of the additional information the irc bot gives might be unnecessary. If you think it is necessary, it's easy enough to add in.

You do need to install the [Ranger](https://github.com/mrduncan/ranger) package in order to get things up and running, so keep that in mind if you decide to fire this guy up.

The configuration options are pretty self-explanatory. The only one that may be of any interest is the "nickname" field, which is used to direct commands at the bot. If your bot is named "Gordon", then you could talk to it using commands like "hey **gordon** - give me some **advice**", or "I need to know what the current **price** is - can you tell me, **Gordon**?"

There is no specific format for the commands you can send to the bot - as long as the nickname and command are somewhere in the message, the bot will know what he needs to do. Also, both nickname and command are case-insensitive.
