### PR TITLE
Add missing dependency in Kraken exchange

### DIFF
--- a/exchanges/kraken.js
+++ b/exchanges/kraken.js
@@ -1,4 +1,5 @@
 var Kraken = require('kraken-api');
+var moment = require('moment');
 var util = require('../core/util');
 var _ = require('lodash');
 var log = require('../core/log');


### PR DESCRIPTION
Added 'moment' dependency. It is required for the retry method which will crash without it.

Crash log (without this fix) looks like this:

```
2014-01-26 14:13:52 (DEBUG):    Requested XBT/LTC trade data from Kraken ...

TypeError: Object function () {
                if (!warned && console && console.warn) {
                    warned = true;
                    console.warn(
                            "Accessing Moment through the global scope is " +
                            "deprecated, and will be removed in an upcoming " +
                            "release.");
                }
                return local_moment.apply(null, arguments);
            } has no method 'duration'
    at Trader.retry (/home/ubuntu/gekko/exchanges/kraken.js:66:22)
    at bound (/home/ubuntu/gekko/node_modules/lodash/dist/lodash.js:729:21)
    at process (/home/ubuntu/gekko/exchanges/kraken.js:95:19)
    at KrakenClient.bound (/home/ubuntu/gekko/node_modules/lodash/dist/lodash.js:729:21)
    at Request._callback (/home/ubuntu/gekko/node_modules/kraken-api/kraken.js:137:22)
    at Request.self.callback (/home/ubuntu/gekko/node_modules/kraken-api/node_modules/request/request.js:122:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (/home/ubuntu/gekko/node_modules/kraken-api/node_modules/request/request.js:888:14)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/home/ubuntu/gekko/node_modules/kraken-api/node_modules/request/request.js:839:12)
```
