### PR TITLE
Fix portfolio

### DIFF
--- a/core/portfolioManager.js
+++ b/core/portfolioManager.js
@@ -296,7 +296,7 @@ Manager.prototype.checkOrder = function() {
 Manager.prototype.logPortfolio = function() {
   log.info(this.exchange.name, 'portfolio:');
   _.each(this.portfolio, function(fund) {
-    log.info('\t', fund.name + ':', fund.amount.toFixed());
+    log.info('\t', fund.name + ':', fund.amount);
   });
 }
 


### PR DESCRIPTION
I am no js coder, so please verify if it won't affect anything else. But with this modification the portfolio manager displays correct values from BTC-e portfolio, without this it just displays zeros by all assets / currencies. 

I have compared the files between version 0.0.7 and the latest and this was the only major change, I have tested it and it works correctly, but I just don't know if it won't affect any other modules / plugins.
