### PR TITLE
Add most of missing npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "async": "0.2.x",
     "bitfinex-fork": "0.3.4",
     "bitstamp": "0.1.x",
+    "bitx": "^1.5.0",
     "btc-e": "0.0.x",
+    "btcchina": "0.1.x",
     "cexio": "0.0.x",
     "kraken-api": "0.1.x",
     "lakebtc_nodejs": "0.1.x",
@@ -24,8 +26,7 @@
     "poloniex.js": "0.0.6",
     "semver": "2.2.1",
     "sqlite3": "3.1.3",
-    "zaif.jp": "^0.1.4",
-    "btcchina": "0.1.x"
+    "zaif.jp": "^0.1.4"
   },
   "devDependencies": {
     "chai": "^2.0.0",


### PR DESCRIPTION
`okcoincn` is required in `exchanges\okcoin.js` but doesn't even exist in npm registry.
npm couldn't install `node-xmpp`, it recommends to use `node-xmpp-client / node-xmpp-server / node-xmpp-component` instead.
`talib` package failed to install because of my not supported OS (Windows, obviously).
