### PR TITLE
Fix syntax error in exchanges/kraken.js

### DIFF
--- a/exchanges/kraken.js
+++ b/exchanges/kraken.js
@@ -151,7 +151,7 @@ Trader.prototype.getTicker = function(callback) {
     if(!_.isEmpty(data.error))
       err = data.error;
 
-    if (err))
+    if (err)
       return log.error('unable to get ticker', JSON.stringify(err));
 
     var result = data.result[this.pair];


### PR DESCRIPTION
This fixes this syntax error:

```
gekko/exchanges/kraken.js:154
    if (err))
            ^
SyntaxError: Unexpected token )
    at Object.exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:513:28)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at checkExchangeTrades (gekko/plugins/tradingAdvisor.js:26:22)
    at Actor.prepareHistoricalData (gekko/plugins/tradingAdvisor.js:116:3)
```

It was introduced in commit 620f9aa921 .
