### PR TITLE
Fix incorrect file existence check and fix npm test

### DIFF
--- a/core/util.js
+++ b/core/util.js
@@ -17,7 +17,7 @@ var util = {
   getConfig: function() {
     if(_config)
       return _config;
-    var configFile = path.resolve(program.config || util.dirs().gekko + 'config');
+    var configFile = path.resolve(program.config || util.dirs().gekko + 'config.js');
 
     if(!fs.existsSync(configFile))
       util.die('Cannot find a config file.');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bitcoin"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha -u tdd --reporter spec"
+    "test": "./node_modules/.bin/mocha test/*.js -u tdd --reporter spec"
   },
   "author": "Mike van Rossum <mike@mvr.me>",
   "dependencies": {


### PR DESCRIPTION
Not sure why is this commit https://github.com/askmike/gekko/commit/b39fd1f3aa5c71eb9f8f1ff10ce471e3d1547caa merged into the branch `stable` because Node will check for existence of a directory with name `config` instead of `config.js`, so it won't add `.js` extension for you obviously.
Next thing this commit fixes is `npm test`. First cause it is failing is the issue above. Not sure what's the second one but after I've added `test/*.js`, `npm test` stopped failing.
