### PR TITLE
updated cexio exchange

### DIFF
--- a/exchanges.js
+++ b/exchanges.js
@@ -92,12 +92,19 @@ var exchanges = [
     slug: 'cexio',
     direct: false,
     infinityOrder: false,
-    currencies: ['BTC'],
-    assets: ['GHS'],
+    currencies: ['BTC','USD','EUR','RUB'],
+    assets: ['GHS','BTC','ETH','LTC'],
     markets: [
-      {
-        pair: ['BTC', 'GHS'], minimalOrder: { amount: 0.000001, unit: 'currency' }
-      }
+      { pair: ['BTC', 'GHS'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['BTC', 'LTC'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['EUR', 'LTC'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['USD', 'LTC'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['RUB', 'BTC'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['USD', 'BTC'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['EUR', 'BTC'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['BTC', 'ETH'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['USD', 'ETH'], minimalOrder: { amount: 0.000001, unit: 'currency' } },
+      { pair: ['EUR', 'ETH'], minimalOrder: { amount: 0.000001, unit: 'currency' } }
     ],
     requires: ['key', 'secret', 'username'],
     providesHistory: false,

--- a/exchanges/cexio.js
+++ b/exchanges/cexio.js
@@ -9,7 +9,9 @@ var Trader = function(config) {
   this.user = config.username;
   this.key = config.key;
   this.secret = config.secret;
-  this.pair = 'ghs_' + config.currency.toLowerCase();
+  this.currency = config.currency.toUpperCase();
+  this.asset = config.asset.toUpperCase();
+  this.pair = this.asset + '_' + this.currency;
   this.name = 'cex.io';
 
   this.cexio = new CEXio(
@@ -46,7 +48,7 @@ Trader.prototype.buy = function(amount, price, callback) {
   amount = Math.floor(amount);
   amount /= 100000000;
 
-  log.debug('BUY', amount, 'GHS @', price, 'BTC');
+  log.debug('BUY', amount, this.asset, '@', price, this.currency);
 
   var set = function(err, data) {
     if(err)
@@ -71,7 +73,7 @@ Trader.prototype.sell = function(amount, price, callback) {
   // test placing orders which will not be filled
   //price *= 10; price = price.toFixed(8);
 
-  log.debug('SELL', amount, 'GHS @', price, 'BTC');
+  log.debug('SELL', amount, this.asset, '@', price, this.currency);
 
   var set = function(err, data) {
     if(err)
@@ -149,7 +151,7 @@ Trader.prototype.getTicker = function(callback) {
 Trader.prototype.getFee = function(callback) {
   // cexio does currently don't take a fee on trades
   // TODO: isn't there an API call for this?
-  callback(false, 0.0);
+  callback(false, 0.002);
 }
 
 Trader.prototype.checkOrder = function(order, callback) {
@@ -184,3 +186,4 @@ Trader.prototype.cancelOrder = function(order) {
 }
 
 module.exports = Trader;
+


### PR DESCRIPTION
cexio exchange is not limited to ghs/btc pair anymore and underlying cexio library can handle more asset/currency pairs. this patch should enable gekko to use them.
