### PR TITLE
fix toFixed is not a function

### DIFF
--- a/plugins/trader/portfolioManager.js
+++ b/plugins/trader/portfolioManager.js
@@ -300,7 +300,8 @@ Manager.prototype.checkOrder = function() {
 Manager.prototype.logPortfolio = function() {
   log.info(this.exchange.name, 'portfolio:');
   _.each(this.portfolio, function(fund) {
-    log.info('\t', fund.name + ':', fund.amount.toFixed(12));
+    let fundAmount = parseFloat(fund.amount)
+    log.info('\t', fund.name + ':', fundAmount.toFixed(12));
   });
 };
 


### PR DESCRIPTION
Hi. Found a bug when i turned on config.trader.enabled to "true". It throws an error

TypeError: fund.amount.toFixed is not a function
    at /home/arielcaba/gekko/plugins/trader/portfolioManager.js:303:45
    at Function.forEach (/home/arielcaba/gekko/node_modules/lodash/dist/lodash.js:3298:15)
    at Manager.logPortfolio (/home/arielcaba/gekko/plugins/trader/portfolioManager.js:302:5)
    at bound [as logPortfolio] (/home/arielcaba/gekko/node_modules/lodash/dist/lodash.js:729:21)
    at prepare (/home/arielcaba/gekko/plugins/trader/portfolioManager.js:57:10)
    at bound (/home/arielcaba/gekko/node_modules/lodash/dist/lodash.js:729:21)
    at /home/arielcaba/gekko/node_modules/async/lib/async.js:232:13
    at /home/arielcaba/gekko/node_modules/async/lib/async.js:142:25
    at /home/arielcaba/gekko/node_modules/async/lib/async.js:229:17
    at /home/arielcaba/gekko/node_modules/async/lib/async.js:556:34

Tested on
Linux 4.4.0-45-generic 
#66-Ubuntu SMP
x86_64 x86_64 x86_64 GNU/Linux
node.js v6.2.2