### PR TITLE
Corrected loaders and typo

### DIFF
--- a/web/vue/package.json
+++ b/web/vue/package.json
@@ -7,7 +7,6 @@
     "dev": "cross-env NODE_ENV=development webpack-dev-server --open --inline --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
-  "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.0.0",
     "babel-loader": "^6.0.0",
@@ -21,6 +20,7 @@
     "superagent-no-cache": "uditalias/superagent-no-cache",
     "vue": "^2.0.1",
     "vue-loader": "^9.7.0",
+    "vue-router": "^2.0.3",
     "webpack": "^2.1.0-beta.25",
     "webpack-dev-server": "^2.1.0-beta.0"
   }

--- a/web/vue/src/backtester/backtestConfigBuilder.vue
+++ b/web/vue/src/backtester/backtestConfigBuilder.vue
@@ -7,7 +7,7 @@
 
 <script>
 
-import datasetPicker from '../global/configbuilder/datasetPicker.vue'
+import datasetPicker from '../global/configbuilder/datasetpicker.vue'
 import stratPicker from '../global/configbuilder/stratpicker.vue'
 import _ from 'lodash'
 

--- a/web/vue/src/layout/footer.vue
+++ b/web/vue/src/layout/footer.vue
@@ -7,8 +7,8 @@
 </template>
 
 <script>
-const gekkoPackage = require('json!../../../../package.json');
-const uiPackage = require('json!../../package.json');
+const gekkoPackage = require('../../../../package.json');
+const uiPackage = require('../../package.json');
 
 export default {
   data: () => {

--- a/web/vue/webpack.config.js
+++ b/web/vue/webpack.config.js
@@ -14,22 +14,26 @@ module.exports = {
     rules: [
       {
         test: /\.vue$/,
-        loader: 'vue',
+        loader: 'vue-loader',
         options: {
           // vue-loader options go here
         }
       },
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
         exclude: /node_modules/
       },
       {
         test: /\.(png|jpg|gif|svg)$/,
-        loader: 'file',
+        loader: 'file-loader',
         options: {
           name: '[name].[ext]?[hash]'
         }
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
       }
     ]
   },


### PR DESCRIPTION
New webpack requires loaders to be defined with their full name.
Thus I moved the `json` loader require to the webpack config as well.
There was also a vue component require which had a name typo.

I don't know how it could happen, but the first commit author is wrong because it's not me...
I've corrected the commit author with the second one.
Anyway, I did both commits ;)

Cheers,
M.