### PR TITLE
Add ability to run gekko in a docker container using docker-compose.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:7.4-onbuild

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You need to download Gekko's dependencies, which can easily be done with [npm](h
 
 Docker user? Installing and running gekko is simple on Docker with the following command:
 
-    docker run -d -v /path/to/your/config.js:/usr/src/gekko/config.js --name gekko barnumd/gekko` 
+    docker run -d -v /path/to/your/config.js:/usr/src/gekko/config.js --name gekko barnumd/gekko 
 
 To see process logs: `docker logs --follow gekko`. More info can be found [here](https://hub.docker.com/r/barnumd/gekko/).
 

--- a/core/talib.js
+++ b/core/talib.js
@@ -215,7 +215,7 @@ methods.bbands = {
             name: "BBANDS",
             inReal: data.close,
             startIdx: 0,
-            endIdx: data.length - 1,
+            endIdx: data.close.length - 1,
             optInTimePeriod: params.optInTimePeriod,
             optInNbDevUp: params.optInNbDevUp,
             optInNbDevDn: params.optInNbDevDn,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  gekko:
+    build: .
+    command: "node gekko"
+    volumes:
+      - ./:/usr/src/app
+      - /usr/src/app/node_modules

--- a/docs/Trading_methods.md
+++ b/docs/Trading_methods.md
@@ -107,7 +107,7 @@ You can configure these parameters for MACD in config.js:
 
 ### PPO
 
-Very similar to MACD but also a little different, read more [here](http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:price_oscillators_pp).
+Very similar to MACD but also a little different, read more [here](http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:price_oscillators_ppo).
 
     // PPO settings:
     config.PPO = {


### PR DESCRIPTION
Rationale: Adding docker-compose makes it easier for contributers and
end-users to interact with their docker containers. For example,
setting up and running gekko using docker-compose could be as easy as
`docker-compose up gekko`. Simply starting, stopping or restarting it as
a daemon could be `docker-compose start`, `docker-compose stop`, or
`docker-compose restart` respectively.