### PR TITLE
#538 (silent failure when buying on Bitstamp)

### DIFF
--- a/exchanges/bitstamp.js
+++ b/exchanges/bitstamp.js
@@ -75,14 +75,18 @@ Trader.prototype.getFee = function(callback) {
 
 Trader.prototype.buy = function(amount, price, callback) {
   var set = function(err, result) {
-    if(err || result.error)
-      return log.error('unable to buy:', err, result);
+    if(err || result.status === "error")
+      return log.error('unable to buy:', err, result.reason);
 
     callback(null, result.id);
   }.bind(this);
 
   // TODO: fees are hardcoded here?
   // prevent: Ensure that there are no more than 8 digits in total.
+  
+  //Decrease amount by 1% to avoid trying to buy more than balance allows.
+  amount -= (amount / 100) * 1;
+  
   amount *= 100000000;
   amount = Math.floor(amount);
   amount /= 100000000;
@@ -97,9 +101,9 @@ Trader.prototype.buy = function(amount, price, callback) {
 }
 
 Trader.prototype.sell = function(amount, price, callback) {
-  var set = function(err, result) {
+  var set = function(err, result.status === "error") {
     if(err || result.error)
-      return log.error('unable to sell:', err, result);
+      return log.error('unable to sell:', err, result.reason);
 
     callback(null, result.id);
   }.bind(this);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "async": "0.2.x",
     "bitexthai": "^0.1.0",
     "bitfinex-api-node": "0.2.9",
-    "bitstamp": "0.3.x",
+    "bitstamp": "1.0.x",
     "bitx": "^1.5.0",
     "btc-china-fork": "0.0.6",
     "btc-e": "0.0.x",


### PR DESCRIPTION
I ran into issue #538 and after some research I found that:
1) The bitstamp.js exchange file didn't handle errors coming from the servers correctly
and
2) It failed because it was trying to buy too much. As a workaround I have decreased the amount to buy with 1% but obviously the original calculation goes wrong somewhere.
