### PR TITLE
Fix postresql adapter

### DIFF
--- a/plugins/postgresql/handle.js
+++ b/plugins/postgresql/handle.js
@@ -8,13 +8,13 @@ var dirs = util.dirs();
 
 var log = require(util.dirs().core + 'log');
 
-var adapter = config.adapters.postgresql;
+var adapter = config.postgresql;
 
 // verify the correct dependencies are installed
 var pluginHelper = require(dirs.core + 'pluginUtil');
 var pluginMock = {
   slug: 'postgresql adapter',
-  dependencies: config.adapters.postgresql.dependencies
+  dependencies: config.postgresql.dependencies
 };
 
 var cannotLoad = pluginHelper.cannotLoad(pluginMock);
@@ -30,10 +30,10 @@ var dbName = config.watch.exchange.toLowerCase();
 
 var mode = util.gekkoMode();
 
-var connectionString = config.adapters.postgresql.connectionString+"/postgres";
+var connectionString = config.postgresql.connectionString+"/postgres";
 
 var checkClient = new pg.Client(connectionString);
-var client = new pg.Client(config.adapters.postgresql.connectionString+"/"+dbName);
+var client = new pg.Client(config.postgresql.connectionString+"/"+dbName);
 
 /* Postgres does not have 'create database if not exists' so we need to check if the db exists first.
 This requires connecting to the default postgres database first. Your postgres user will need appropriate rights. */

--- a/plugins/postgresql/handle.js
+++ b/plugins/postgresql/handle.js
@@ -62,6 +62,8 @@ checkClient.connect(function(err){
         });
       }else if(mode === 'backtest') {
         util.die(`History database does not exist for exchange ${config.watch.exchange}.`);
+      }else{
+        util.die(`Start gekko first in realtime mode to create tables. You are currently in the '${mode}' mode.`);
       }
     }else{ //database exists
       log.debug("Database exists: "+dbName);

--- a/plugins/postgresql/reader.js
+++ b/plugins/postgresql/reader.js
@@ -83,11 +83,14 @@ Reader.prototype.mostRecentWindow = function(from, to, next) {
   });
 }
 
-Reader.prototype.tableExists = function(name, next) {
+Reader.prototype.tableExists = function (name, next) {
   this.db.query(`
-    SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name='${postgresUtil.table(name)}';
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema='${postgresUtil.schema()}'
+      AND table_name='${postgresUtil.table(name)}';
   `, function(err, result) {
-    if(err) {
+    if (err) {
       return util.die('DB error at `tableExists`');
     }
 

--- a/plugins/postgresql/reader.js
+++ b/plugins/postgresql/reader.js
@@ -84,19 +84,14 @@ Reader.prototype.mostRecentWindow = function(from, to, next) {
 }
 
 Reader.prototype.tableExists = function(name, next) {
+  this.db.query(`
+    SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name='${postgresUtil.table(name)}';
+  `, function(err, result) {
+    if(err) {
+      return util.die('DB error at `tableExists`');
+    }
 
-  const query = this.db.query(`
-    SELECT COUNT(*) FROM ${postgresUtil.table(name)}
-  `);
-
-  const rows = [];
-
-  query.on('row', (row) => {
-    rows.push(row);
-  });
-
-  query.on('end', () => {
-    next(null, rows.length === 1 && rows[0].count > 0);
+    next(null, result.rows.length === 1);
   });
 }
 

--- a/plugins/postgresql/reader.js
+++ b/plugins/postgresql/reader.js
@@ -22,7 +22,16 @@ Reader.prototype.mostRecentWindow = function(from, to, next) {
   SELECT start from ${postgresUtil.table('candles')}
   WHERE start <= ${to} AND start >= ${from}
   ORDER BY start DESC
-  `);
+  `, function (err, result) {
+    if (err) {
+      // bail out if the table does not exist
+      if (err.message.indexOf(' does not exist') !== -1)
+        return next(false);
+
+      log.error(err);
+      return util.die('DB error while reading mostRecentWindow');
+    }
+  });
 
   var rows = [];
   query.on('row', function(row) {

--- a/plugins/postgresql/scanner.js
+++ b/plugins/postgresql/scanner.js
@@ -1,0 +1,71 @@
+const _ = require('lodash');
+const async = require('async');
+var pg = require('pg');
+
+const util = require('../../core/util.js');
+const config = util.getConfig();
+const dirs = util.dirs();
+var postgresUtil = require('./util');
+
+var connectionString = config.postgresql.connectionString;
+
+
+module.exports = done => {
+  var scanClient = new pg.Client(connectionString+"/postgres");
+
+  let markets = [];
+
+  scanClient.connect(function (err) {
+    if(err){
+      util.die(err);
+    }
+
+    var query = scanClient.query("select datname from pg_database", function (err, result) {
+
+      async.each(result.rows, (dbRow, next) => {
+
+        var scanTablesClient = new pg.Client(connectionString + "/" + dbRow.datname);
+        var dbName = dbRow.datname;
+
+        scanTablesClient.connect(function (err) {
+          if (err) {
+            return next();
+          }
+
+          var query = scanTablesClient.query(`
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema='${postgresUtil.schema()}';
+          `, function(err, result) {
+            if (err) {
+              return util.die('DB error at `scanning tables`');
+            }
+
+            _.each(result.rows, table => {
+              let parts = table.table_name.split('_');
+              let first = parts.shift();
+              if(first === 'candles')
+                markets.push({
+                  exchange: dbName,
+                  currency: _.first(parts),
+                  asset: _.last(parts)
+                });
+            });
+
+            scanTablesClient.end();
+
+            next();
+          });
+        });
+
+      },
+      // got all tables!
+      err => {
+        scanClient.end();
+        done(err, markets);
+      });
+
+    });
+
+  });
+}

--- a/plugins/postgresql/util.js
+++ b/plugins/postgresql/util.js
@@ -6,9 +6,14 @@ var settings = {
   pair: [watch.currency, watch.asset]
 }
 
+function useLowerCaseTableNames() {
+  return !config.postgresql.noLowerCaseTableName;
+}
+
 module.exports = {
   settings: settings,
   table: function(name) {
-    return [name, settings.pair.join('_')].join('_');
+    var fullName = [name, settings.pair.join('_')].join('_');
+    return useLowerCaseTableNames() ? fullName.toLowerCase() : fullName;
   }
 }

--- a/plugins/postgresql/util.js
+++ b/plugins/postgresql/util.js
@@ -12,6 +12,9 @@ function useLowerCaseTableNames() {
 
 module.exports = {
   settings: settings,
+  schema: function () {
+    return config.postgresql.schema ? config.postgresql.schema : 'public';
+  },
   table: function(name) {
     var fullName = [name, settings.pair.join('_')].join('_');
     return useLowerCaseTableNames() ? fullName.toLowerCase() : fullName;


### PR DESCRIPTION
Postgresql adapter seems to be broken since commit 837d18e3e1dec54c. This commit changed `config.adapters.sqlite` to `config.sqlite` for sqlite and missed to do so for postgresql.

If running gekko on empty postgresql server, a new DB poloniex is created. Gekko then fails with `relation '"candles_usdt_btc" does not exist`. The second commit fixes it in a way it is already fixed in sqlite.
