### PR TITLE
Remove defaults for computed values

### DIFF
--- a/web/vue/src/components/global/configbuilder/marketpicker.vue
+++ b/web/vue/src/components/global/configbuilder/marketpicker.vue
@@ -27,8 +27,6 @@ export default {
 
       // defaults:
       exchange: 'poloniex',
-      currency: 'BTC',
-      asset: 'ETH',
       market: 'USDT/BTC'
     };
   },


### PR DESCRIPTION
I had issues the asset and currency didn't update when i switched the default market. (And because i was using Kraken it complained about the default BTC value)
Removing the default values for the computed fields seem to fix this.