### PR TITLE
Adds config option for tickrate - exchange watch interval.

### DIFF
--- a/core/budfox/heart.js
+++ b/core/budfox/heart.js
@@ -6,7 +6,9 @@ var log = require(util.dirs().core + 'log');
 var _ = require('lodash');
 var moment = require('moment');
 
-if(util.getConfig().watch.exchange === 'okcoin')
+if (util.getConfig().watch.tickrate)
+  var TICKRATE = util.getConfig().watch.tickrate;
+else if(util.getConfig().watch.exchange === 'okcoin')
   var TICKRATE = 2;
 else
   var TICKRATE = 20;

--- a/sample-config.js
+++ b/sample-config.js
@@ -18,7 +18,12 @@ config.watch = {
   // see https://github.com/askmike/gekko#supported-exchanges
   exchange: 'poloniex',
   currency: 'USDT',
-  asset: 'BTC'
+  asset: 'BTC',
+
+  // You can set your own tickrate (refresh rate).
+  // If you don't set it, the defaults are 2 sec for
+  // okcoin and 20 sec for all other exchanges.
+  // tickrate: 20
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The tick interval was hardcoded to 2 seconds for okcoin exchange
and to 20 seconds for any other exchange. This patch adds config variable
`config.watch.tickrate` which can override this defaults.

If tickrate option is not set, the default values will still be used - current
gekko apps will work as before.