### PR TITLE
Bigger candles

### DIFF
--- a/core/budfox/marketFetcher.js
+++ b/core/budfox/marketFetcher.js
@@ -1,8 +1,8 @@
-// 
-// The fetcher is responsible for fetching new 
+//
+// The fetcher is responsible for fetching new
 // market data at the exchange on interval. It will emit
 // the following events:
-// 
+//
 // - `trades batch` - all new trades.
 // - `trade` - the most recent trade after every fetch
 
@@ -25,7 +25,7 @@ var Fetcher = function(config) {
   var DataProvider = require(util.dirs().gekko + 'exchanges/' + provider);
   _.bindAll(this);
 
-  // Create a public dataProvider object which can retrieve live 
+  // Create a public dataProvider object which can retrieve live
   // trade information from an exchange.
   this.watcher = new DataProvider(config.watch);
 
@@ -84,6 +84,8 @@ Fetcher.prototype.fetch = function() {
     since = false;
 
   this.tries = 0;
+  this.fetchStartAt = (new Date).getTime();
+
   log.debug('Requested', this.pair, 'trade data from', this.exchange.name, '...');
   this._fetch(since);
 }
@@ -98,6 +100,9 @@ Fetcher.prototype.processTrades = function(err, trades) {
     setTimeout(this._fetch, +moment.duration('s', 1));
     return;
   }
+
+  trades.lag = ((new Date).getTime()) - this.fetchStartAt;
+
   this.batcher.write(trades);
 }
 

--- a/core/budfox/tradeBatcher.js
+++ b/core/budfox/tradeBatcher.js
@@ -1,6 +1,6 @@
-// 
+//
 // Small wrapper that only propogates new trades.
-// 
+//
 // Expects trade batches to be written like:
 // [
 //  {
@@ -16,7 +16,7 @@
 //    amount: x
 //  }
 // ]
-// 
+//
 // Emits 'new trades' event with:
 // {
 //   amount: x,
@@ -25,9 +25,10 @@
 //   first: (trade),
 //   last: (trade)
 //   data: [
-//      // batch of new trades with 
+//      // batch of new trades with
 //      // moments instead of timestamps
-//   ]
+//   ],
+//   lag: (integer) exchange lag in ms
 // }
 
 var _ = require('lodash');
@@ -81,7 +82,8 @@ TradeBatcher.prototype.write = function(batch) {
     end: last.date,
     last: last,
     first: first,
-    data: momentBatch
+    data: momentBatch,
+    lag: batch.lag
   });
 
   this.last = last[this.tid];

--- a/core/tools/candleLoader.js
+++ b/core/tools/candleLoader.js
@@ -50,7 +50,9 @@ var doneFn = () => {
 module.exports = function(candleSize, _next) {
   next = _.once(_next);
 
-  batcher = new CandleBatcher(candleSize)
+  var candleVersion = config.candleWriter.version;
+
+  batcher = new CandleBatcher({candleSize,candleVersion})
     .on('candle', handleBatchedCandles);
 
   getBatch();

--- a/plugins/mongodb/writer.js
+++ b/plugins/mongodb/writer.js
@@ -31,6 +31,8 @@ Store.prototype.writeCandles = function writeCandles () {
   }
 
   var candles = [];
+  var version = config.candleWriter.version;
+
   _.each(this.candleCache, candle => {
     var mCandle = {
       time: moment().utc(),
@@ -44,6 +46,16 @@ Store.prototype.writeCandles = function writeCandles () {
       trades: candle.trades,
       pair: this.pair
     };
+
+    if(version === 2) {
+      _.extend(mCandle, {
+        buyVolume: candle.buyVolume,
+        buyTrades: candle.buyTrades,
+        lag: candle.lag,
+        raw: candle.raw
+      });
+    }
+
     candles.push(mCandle);
   });
 

--- a/plugins/postgresql/writer.js
+++ b/plugins/postgresql/writer.js
@@ -15,19 +15,10 @@ var Store = function(done, pluginMeta) {
 }
 
 Store.prototype.upsertTables = function() {
+  var version = config.candleWriter.version;
+
   var createQueries = [
-    `CREATE TABLE IF NOT EXISTS
-    ${postgresUtil.table('candles')} (
-      id BIGSERIAL PRIMARY KEY,
-      start integer UNIQUE,
-      open double precision NOT NULL,
-      high double precision NOT NULL,
-      low double precision NOT NULL,
-      close double precision NOT NULL,
-      vwp double precision NOT NULL,
-      volume double precision NOT NULL,
-      trades INTEGER NOT NULL
-    );`
+    prepareTableSql(version)
   ];
 
   var next = _.after(_.size(createQueries), this.done);
@@ -42,23 +33,12 @@ Store.prototype.writeCandles = function() {
     return;
   }
 
-  var stmt = `
-  INSERT INTO ${postgresUtil.table('candles')}
-  (start, open, high,low, close, vwp, volume, trades)
-  values($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT DO NOTHING;
-  `;
+  var version = config.candleWriter.version;
+
+  var stmt = prepareCandleSql(version);
 
   _.each(this.cache, candle => {
-    this.db.query(stmt,[
-      candle.start.unix(),
-      candle.open,
-      candle.high,
-      candle.low,
-      candle.close,
-      candle.vwp,
-      candle.volume,
-      candle.trades
-    ]);
+    this.db.query(stmt, prepareCandleData(candle, version));
   });
 
   this.cache = [];
@@ -76,6 +56,77 @@ var processCandle = function(candle, done) {
 
 if(config.candleWriter.enabled){
   Store.prototype.processCandle = processCandle;
+}
+
+var prepareCandleData = function(candle, version) {
+  var data = [
+    candle.start.unix(),
+    candle.open,
+    candle.high,
+    candle.low,
+    candle.close,
+    candle.vwp,
+    candle.volume,
+    candle.trades
+  ];
+
+  if(version === 2) {
+    data = data.concat([
+      candle.buyVolume,
+      candle.buyTrades,
+      candle.lag,
+      JSON.stringify(candle.raw)
+    ]);
+  }
+
+  return data;
+}
+
+var prepareCandleSql = function(version) {
+  switch(version) {
+    case 2:
+      var sql = `
+        INSERT INTO ${postgresUtil.table('candles')}
+        (start, open, high,low, close, vwp, volume, trades, buy_volume, buy_trades, lag, raw)
+        values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::JSON) ON CONFLICT DO NOTHING;`;
+      break;
+    default:
+      var sql = `
+        INSERT INTO ${postgresUtil.table('candles')}
+        (start, open, high,low, close, vwp, volume, trades)
+        values($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT DO NOTHING;`;
+  }
+
+  return sql;
+}
+
+var prepareTableSql = function(version) {
+  var fields = `
+      id BIGSERIAL PRIMARY KEY,
+      start integer UNIQUE,
+      open double precision NOT NULL,
+      high double precision NOT NULL,
+      low double precision NOT NULL,
+      close double precision NOT NULL,
+      vwp double precision NOT NULL,
+      volume double precision NOT NULL,
+      trades INTEGER NOT NULL
+  `;
+
+  if(version === 2) {
+    fields += `,
+      buy_volume double precision NOT NULL,
+      buy_trades INTEGER NOT NULL,
+      lag INTEGER NOT NULL,
+      raw jsonb
+    `;
+  }
+
+  return `
+    CREATE TABLE IF NOT EXISTS
+      ${postgresUtil.table('candles')} (
+      ${fields}
+    );`
 }
 
 module.exports = Store;

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -16,7 +16,10 @@ var Actor = function(done) {
 
   this.done = done;
 
-  this.batcher = new CandleBatcher(config.tradingAdvisor.candleSize);
+  var candleSize = config.tradingAdvisor.candleSize;
+  var candleVersion = config.candleWriter.version;
+
+  this.batcher = new CandleBatcher({candleSize, candleVersion});
 
   this.methodName = config.tradingAdvisor.method;
 

--- a/sample-config.js
+++ b/sample-config.js
@@ -327,6 +327,12 @@ config.redisBeacon = {
 }
 
 config.candleWriter = {
+  // Candles can be created in two versions. Version 1
+  // is the defalt one, version 2 has some additional
+  // fields (see top comments in candleCreator.js).
+  // Note, that you need to patch your DB tables with these
+  // additional fields if you've created tables for v1 candles.
+  version: 2,
   enabled: false
 }
 

--- a/sample-config.js
+++ b/sample-config.js
@@ -332,7 +332,7 @@ config.candleWriter = {
   // fields (see top comments in candleCreator.js).
   // Note, that you need to patch your DB tables with these
   // additional fields if you've created tables for v1 candles.
-  version: 2,
+  version: 1,
   enabled: false
 }
 

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -89,32 +89,30 @@
     ]
   },
   "candleWriter": {
-    "adapter": "sqlite",
     "enabled": true
   },
-  "adapters": {
-    "sqlite": {
-      "path": "plugins/sqlite",
-      "dataDirectory": "./history",
-      "version": 0.1,
-      "dependencies": [
-        {
-          "module": "sqlite3",
-          "version": "3.1.4"
-        }
-      ]
-    },
-    "postgresql": {
-      "path": "plugins/postgresql",
-      "version": 0.1,
-      "connectionString": "postgres://user:pass@localhost:5432",
-      "dependencies": [
-        {
-          "module": "pg",
-          "version": "6.1.0"
-        }
-      ]
-    }
+  "adapter": "sqlite",
+  "sqlite": {
+    "path": "plugins/sqlite",
+    "dataDirectory": "./history",
+    "version": 0.1,
+    "dependencies": [
+      {
+        "module": "sqlite3",
+        "version": "3.1.4"
+      }
+    ]
+  },
+  "postgresql": {
+    "path": "plugins/postgresql",
+    "version": 0.1,
+    "connectionString": "postgres://user:pass@localhost:5432",
+    "dependencies": [
+      {
+        "module": "pg",
+        "version": "6.1.0"
+      }
+    ]
   },
   "backtest": {
     "adapter": "sqlite",


### PR DESCRIPTION
This PR is about new fields in candles.

We need a couple of new [fields](https://github.com/RatkoR/gekko/blob/bigger_candles/core/budfox/candleCreator.js#L43) in candles. I'd like you to look over the changes and say what is OK and what needs to change to get this beast merged.

The idea is simple: add 4 new fields to candle data and to the DB schema.

The patch is a bit 'ugly', because I didn't want existing users to worry about this change. I added a `version` [config](https://github.com/RatkoR/gekko/blob/bigger_candles/sample-config.js#L335) variable: no version id (or version 1) means candles work as they work now. Version 2 means candles have 4 additional fiels.

If user changes candle versions, he'll have to add these new fields manually to his existing DB. User is intentionally changing config, so he probably knows what he's doing and a short notice or a wiki page would be enough to help him sort out the DB. Normal users won't change this config and will be unaffected. Also, if you change version before creating DB, tables will be created for you correctly.

Since this `version` variable is a numeric one, you can just increment it  to `version: 3` and add other new fields - if you'll ever feel you need some more. What I want to say is that this version thing is expandable.

But.. looking at the patch maybe there's another (better) way. What if we don't add `version` parameter, but rather an array of additional fields user can have in candles. Fields that are in candle data now are mandatory and cannot be removed. But other fields can be just uncommented and you get them in your next candles.

Maybe something like:

```
/**
 * Uncomment to enable additional fields
 * in candles. Note that you'll also have to
 * add new fields to DB if you uncomment it later.
 */

config.candleWriter.additionalFields = [
//  'buyVolume',
//  'buyTrades',
//  'lag',
//  'raw'
]
```

Tell me if you know a better position for `version` or `additionalFields` in config. I didn't find any better place but `candleWriter` node.

----

One last thing: CandleBatcher class had a single argument (`candleSize`). I had to change it to take a second parameter (candleVersion).

Calling it looked strange, because you cannot see immediatelly what those parameters mean. Eg:

```
var cb = new CandleBatcher(2, 1);
```

so I changed it to take options parameter. Eg:

```
var cb = new CandleBatcher({candleSize:2, candleVersion:1});
```

I changed all class invocations and added/changed tests also.