### PR TITLE
Retry certain operations before crashing

### DIFF
--- a/core/util.js
+++ b/core/util.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var semver = require('semver');
 var program = require('commander');
+var retry = require('retry');
 
 var startTime = moment();
 
@@ -160,6 +161,24 @@ var util = {
   },
   getStartTime: function() {
     return startTime;
+  },
+  retry: function(fn, callback) {
+    var operation = retry.operation({
+      retries: 5,
+      factor: 1.2,
+      minTimeout: 1 * 1000,
+      maxTimeout: 3 * 1000
+    });
+ 
+    operation.attempt(function(currentAttempt) {
+      fn(function(err, result) {
+        if (operation.retry(err)) {
+          return;
+        }
+
+        callback(err ? operation.mainError() : null, result);
+      });
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prompt-lite": "0.1.1",
     "pushbullet": "1.4.3",
     "relieve": "^2.1.3",
+    "retry": "^0.10.1",
     "semver": "2.2.1",
     "sqlite3": "3.1.8",
     "stats-lite": "^2.0.4",

--- a/plugins/mailer.js
+++ b/plugins/mailer.js
@@ -81,13 +81,14 @@ Mailer.prototype.setup = function(done) {
 };
 
 Mailer.prototype.mail = function(subject, content, done) {
-
-  this.server.send({
-    text: content,
-    from: mailConfig.from,
-    to: mailConfig.to,
-    subject: mailConfig.tag + subject
-  }, done || this.checkResults);
+  util.retry(function(cb) {
+    this.server.send({
+      text: content,
+      from: mailConfig.from,
+      to: mailConfig.to,
+      subject: mailConfig.tag + subject
+    }, cb);
+  }.bind(this), done || this.checkResults);
 };
 
 Mailer.prototype.processCandle = function(candle, done) {

--- a/plugins/trader/portfolioManager.js
+++ b/plugins/trader/portfolioManager.js
@@ -91,7 +91,7 @@ Manager.prototype.setPortfolio = function(callback) {
 
   }.bind(this);
 
-  this.exchange.getPortfolio(set);
+  util.retry(this.exchange.getPortfolio, set);
 };
 
 Manager.prototype.setFee = function(callback) {
@@ -104,17 +104,20 @@ Manager.prototype.setFee = function(callback) {
     if(_.isFunction(callback))
       callback();
   }.bind(this);
-  this.exchange.getFee(set);
+  util.retry(this.exchange.getFee, set);
 };
 
 Manager.prototype.setTicker = function(callback) {
   var set = function(err, ticker) {
     this.ticker = ticker;
 
+    if(err)
+      util.die(err);
+    
     if(_.isFunction(callback))
       callback();
   }.bind(this);
-  this.exchange.getTicker(set);
+  util.retry(this.exchange.getTicker, set);
 };
 
 // return the [fund] based on the data we have in memory
@@ -225,7 +228,9 @@ Manager.prototype.buy = function(amount, price) {
     amount,
     this.asset,
     'at',
-    this.exchange.name
+    this.exchange.name,
+    'price:',
+    price
   );
   this.exchange.buy(amount, price, this.noteOrder);
 };
@@ -270,7 +275,9 @@ Manager.prototype.sell = function(amount, price) {
     amount,
     this.asset,
     'at',
-    this.exchange.name
+    this.exchange.name,
+    'price:',
+    price
   );
   this.exchange.sell(amount, price, this.noteOrder);
 };


### PR DESCRIPTION
This PR adds retrying to certain requests so that gekko doesn't instantly crash when there's a network error. The mailer was the most problematic, but I've also seen it crash due to the exchange ticker not being available.