### PR TITLE
Add `tradable` capability to Bitfinex trader

### DIFF
--- a/exchanges/bitfinex.js
+++ b/exchanges/bitfinex.js
@@ -217,7 +217,8 @@ Trader.getCapabilities = function () {
         { pair: ['BTC', 'ETH'], minimalOrder: { amount: 0.01, unit: 'asset' } },
     ],
     requires: ['key', 'secret'],
-    tid: 'tid'
+    tid: 'tid',
+    tradable: true
   };
 }
 


### PR DESCRIPTION
Couldn't get the trader to work without this capability. Not sure if it was removed/not added intentionally?