### PR TITLE
Improve error handling for Bitfinex trader

### DIFF
--- a/exchanges/bitfinex.js
+++ b/exchanges/bitfinex.js
@@ -44,6 +44,7 @@ Trader.prototype.retry = function(method, args) {
 }
 
 Trader.prototype.getPortfolio = function(callback) {
+  var args = _.toArray(arguments);
   this.bitfinex.wallet_balances(function (err, data, body) {
 
     if(err && err.message === '401') {
@@ -51,6 +52,9 @@ Trader.prototype.getPortfolio = function(callback) {
       e += 'Double check whether your API key is correct.';
       util.die(e);
     }
+    
+    if(err || !data)
+      return this.retry(this.getPortfolio, args);
 
     // We are only interested in funds in the "exchange" wallet
     data = data.filter(c => c.type === 'exchange');


### PR DESCRIPTION
I had the trader bot die during the night due to trying to call `filter` on `data` which was `undefined`. Not sure why that happened, but this should hopefully make it a bit more resilient.

```
2017-08-05 04:58:26 (INFO):     Trader Received advice to go short. Selling  ETH
/home/gekko/gekko/exchanges/bitfinex.js:56
    data = data.filter(c => c.type === 'exchange');
               ^

TypeError: Cannot read property 'filter' of undefined
    at Trader.<anonymous> (/home/gekko/gekko/exchanges/bitfinex.js:56:16)
    at Request._callback (/home/gekko/gekko/node_modules/bitfinex-api-node/rest.js:66:20)
    at Request.self.callback (/home/gekko/gekko/node_modules/request/request.js:188:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/home/gekko/gekko/node_modules/request/request.js:1171:10)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/home/gekko/gekko/node_modules/request/request.js:1091:12)
    at IncomingMessage.g (events.js:292:16)
```