### PR TITLE
Add EURETH and EURLTC pairs to GDAX exchange file

### DIFF
--- a/exchanges/gdax.js
+++ b/exchanges/gdax.js
@@ -299,6 +299,8 @@ Trader.getCapabilities = function () {
       { pair: ['USD', 'LTC'], minimalOrder: { amount: 0.01, unit: 'asset' } },
       { pair: ['USD', 'ETH'], minimalOrder: { amount: 0.01, unit: 'asset' } },
       { pair: ['EUR', 'BTC'], minimalOrder: { amount: 0.01, unit: 'asset' } },
+      { pair: ['EUR', 'ETH'], minimalOrder: { amount: 0.01, unit: 'asset' } },
+      { pair: ['EUR', 'LTC'], minimalOrder: { amount: 0.01, unit: 'asset' } },      
       { pair: ['GBP', 'BTC'], minimalOrder: { amount: 0.01, unit: 'asset' } },
       { pair: ['BTC', 'LTC'], minimalOrder: { amount: 0.01, unit: 'asset' } },
       { pair: ['BTC', 'ETH'], minimalOrder: { amount: 0.01, unit: 'asset' } }


### PR DESCRIPTION
GDAX now has EURETH and EURLTC markets that were previously not supported by Gekko. This PR will add support for them.