### PR TITLE
Add SMMA, replace RSI with original study

### DIFF
--- a/strategies/indicators/RSI.js
+++ b/strategies/indicators/RSI.js
@@ -1,23 +1,31 @@
 // required indicators
-var EMA = require('./EMA.js');
+var SMMA = require('./SMMA.js');
 
-var Indicator = function(settings) {
-  this.lastClose = 0;
+var Indicator = function (settings) {
+  this.lastClose = null;
   this.weight = settings.interval;
-  this.weightEma = 2 * this.weight - 1;
-  this.avgU = new EMA(this.weightEma);
-  this.avgD = new EMA(this.weightEma);
+  this.avgU = new SMMA(this.weight);
+  this.avgD = new SMMA(this.weight);
   this.u = 0;
   this.d = 0;
-  this.rs = 0;	
+  this.rs = 0;
   this.rsi = 0;
   this.age = 0;
 }
 
-Indicator.prototype.update = function(candle) {
+Indicator.prototype.update = function (candle) {
   var currentClose = candle.close;
 
-  if(currentClose > this.lastClose) {
+  if (this.lastClose === null) {
+    // Set initial price to prevent invalid change calculation
+    this.lastClose = currentClose;
+
+    // Do not calculate RSI for this reason - there's no change!
+    this.age++;
+    return;
+  }
+
+  if (currentClose > this.lastClose) {
     this.u = currentClose - this.lastClose;
     this.d = 0;
   } else {
@@ -27,11 +35,18 @@ Indicator.prototype.update = function(candle) {
 
   this.avgU.update(this.u);
   this.avgD.update(this.d);
+
   this.rs = this.avgU.result / this.avgD.result;
   this.rsi = 100 - (100 / (1 + this.rs));
 
-  this.age++;
+  if (this.avgD.result === 0 && this.avgU.result !== 0) {
+    this.rsi = 100;
+  } else if (this.avgD.result === 0) {
+    this.rsi = 0;
+  }
+
   this.lastClose = currentClose;
+  this.age++;
 }
 
 module.exports = Indicator;

--- a/strategies/indicators/SMA.js
+++ b/strategies/indicators/SMA.js
@@ -9,7 +9,7 @@ var Indicator = function(weight) {
 
 Indicator.prototype.update = function(price) {
   this.prices[this.age % this.weight] = price;
-  sum = this.prices.reduce(function(a, b) { return a + b; }, 0);
+  var sum = this.prices.reduce(function(a, b) { return a + b; }, 0);
   this.result = sum / this.prices.length;
   this.age++;
 }

--- a/strategies/indicators/SMMA.js
+++ b/strategies/indicators/SMMA.js
@@ -1,0 +1,27 @@
+// required indicators
+var SMA = require('./sma');
+
+var Indicator = function (weight) {
+  this.sma = new SMA(weight);
+  this.weight = weight;
+  this.prices = [];
+  this.result = 0;
+  this.age = 0;
+}
+
+Indicator.prototype.update = function (price) {
+  this.prices[this.age] = price;
+
+  if(this.prices.length < this.weight) {
+    this.sma.update(price);
+  } else if(this.prices.length === this.weight) {
+    this.sma.update(price);
+    this.result = this.sma.result;
+  } else {
+    this.result = (this.result * (this.weight - 1) + price) / this.weight;
+  }
+
+  this.age++;
+}
+
+module.exports = Indicator;

--- a/strategies/indicators/SMMA.js
+++ b/strategies/indicators/SMMA.js
@@ -1,5 +1,5 @@
 // required indicators
-var SMA = require('./sma');
+var SMA = require('./SMA');
 
 var Indicator = function (weight) {
   this.sma = new SMA(weight);

--- a/test/indicators/rsi.js
+++ b/test/indicators/rsi.js
@@ -1,0 +1,53 @@
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should;
+var sinon = require('sinon');
+
+var _ = require('lodash');
+
+var util = require('../../core/util');
+var dirs = util.dirs();
+var INDICATOR_PATH = dirs.indicators;
+
+// Fake input prices to verify all indicators 
+// are working correctly by comparing fresh
+// calculated results to pre calculated results.
+
+// The precalculated results are compared to the Talib repository at
+// https://github.com/wuhkuh/talib
+// (shameless plug, sorry guys ;))
+
+var prices = [81, 24, 75, 21, 34, 25, 72, 92, 99, 2, 86, 80, 76, 8, 87, 75, 32, 65, 41, 9, 13, 26, 56, 28, 65, 58, 17, 90, 87, 86, 99, 3, 70, 1, 27, 9, 92, 68, 9];
+
+describe('indicators/RSI', function() {
+
+  var RSI = require(INDICATOR_PATH + 'RSI');
+
+  var verified_rsi2results = [0, 0, 47.22222222222223, 23.611111111111114, 38.43283582089553, 30.294117647058826, 78.2967032967033, 86.31639722863741, 89.12844036697248, 13.311866264730071, 64.95013850415512, 59.85653017461453, 54.19016363132106, 12.8454188854557, 68.56748255340673, 57.41553886370404, 26.512530826658676, 59.75774345724092, 36.04149739852744, 17.51008036340795, 26.905774699598737, 58.00044863973779, 85.82728624443239, 38.371227493966536, 74.96090570884536, 61.21019495608749, 19.438903652597787, 76.51344601664712, 72.30324117451528, 69.74473974944168, 84.24228523539779, 10.429850167468388, 59.707866801087974, 27.99023519523047, 48.57675474701421, 34.80106793288934, 81.96579567492182, 57.78953245436237, 23.585658801479056];
+  var verified_rsi12results = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 49.44320712694878, 42.432667245873155, 51.2017782300719, 49.94116787991835, 45.55663590860508, 49.284333951746184, 46.74501674557244, 43.4860123510052, 44.01823674189631, 45.82704797004994, 49.90209564896179, 46.351969981868436, 51.34208640997234, 50.37501845071388, 44.96351306736635, 54.464714123844956, 54.04642006918241, 53.895901697369816, 55.6476477612053, 42.60631369413207, 51.2964732419777, 43.83906729252931, 47.00600661743475, 45.08586375053323, 54.44633399991266, 51.6681674437389, 45.44886082103851];
+  var verified_rsi26results = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 46.44444444444444, 50.61070579555701, 50.44298978067838, 50.385107396174675, 51.143071170125296, 45.77270174725033, 49.6130641968312, 46.115177339098764, 47.56394036014283, 46.660676933508505, 51.11283316502063, 49.861270146262456, 46.92369439491447];
+
+  it('should correctly calculate RSI with period 2', function() {
+    var rsi = new RSI({ interval: 2 });
+    _.each(prices, function(p, i) {
+      rsi.update({ close: p });
+      expect(rsi.rsi).to.equal(verified_rsi2results[i]);
+    });
+  });
+
+  it('should correctly calculate RSI with period 12', function() {
+    var rsi = new RSI({ interval: 12 });
+    _.each(prices, function(p, i) {
+      rsi.update({ close: p });
+      expect(rsi.rsi).to.equal(verified_rsi12results[i]);
+    });
+  });
+
+  it('should correctly calculate RSI with period 26', function() {
+    var rsi = new RSI({ interval: 26 });
+    _.each(prices, function(p, i) {
+      rsi.update({ close: p });
+      expect(rsi.rsi).to.equal(verified_rsi26results[i]);
+    });
+  });
+});

--- a/test/indicators/smma.js
+++ b/test/indicators/smma.js
@@ -1,0 +1,53 @@
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should;
+var sinon = require('sinon');
+
+var _ = require('lodash');
+
+var util = require('../../core/util');
+var dirs = util.dirs();
+var INDICATOR_PATH = dirs.indicators;
+
+// Fake input prices to verify all indicators 
+// are working correctly by comparing fresh
+// calculated results to pre calculated results.
+
+// The precalculated results are compared to the Talib repository at
+// https://github.com/wuhkuh/talib
+// (shameless plug, sorry guys ;))
+
+var prices = [81, 24, 75, 21, 34, 25, 72, 92, 99, 2, 86, 80, 76, 8, 87, 75, 32, 65, 41, 9, 13, 26, 56, 28, 65, 58, 17, 90, 87, 86, 99, 3, 70, 1, 27, 9, 92, 68, 9];
+
+describe('indicators/SMMA', function() {
+
+  var SMMA = require(INDICATOR_PATH + 'SMMA');
+
+  var verified_smma2results = [0, 52.5, 63.75, 42.375, 38.1875, 31.59375, 51.796875, 71.8984375, 85.44921875, 43.724609375, 64.8623046875, 72.43115234375, 74.215576171875, 41.1077880859375, 64.05389404296875, 69.52694702148438, 50.76347351074219, 57.881736755371094, 49.44086837768555, 29.220434188842773, 21.110217094421387, 23.555108547210693, 39.77755427360535, 33.88877713680267, 49.44438856840134, 53.72219428420067, 35.361097142100334, 62.68054857105017, 74.84027428552508, 80.42013714276254, 89.71006857138127, 46.355034285690635, 58.17751714284532, 29.58875857142266, 28.29437928571133, 18.647189642855665, 55.32359482142783, 61.661797410713916, 35.33089870535696];
+  var verified_smma12results = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57.583333333333336, 59.118055555555564, 54.8582175925926, 57.53669945987655, 58.991974504886834, 56.74264329614626, 57.43075635480074, 56.061526658567345, 52.1397327703534, 48.878088372823946, 46.97158100842196, 47.72394925772013, 46.08028681957679, 47.656929584612065, 48.518852119227724, 45.89228110929208, 49.5679243501844, 52.687263987669034, 55.46332532202995, 59.09138154519412, 54.41709974976127, 55.7156747706145, 51.15603520639663, 49.14303227253024, 45.797779583152725, 49.64796461788999, 51.177300899732494, 47.66252582475479];
+  var verified_smma26results = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 51.15384615384615, 49.84023668639053, 51.384842967683205, 52.75465669969539, 54.0333237497071, 55.76281129779529, 53.73347240172624, 54.35910807858292, 52.30683469094512, 51.33349489513954, 49.70528355301879, 51.33200341636422, 51.973080208042525, 50.32026943081012];
+
+  it('should correctly calculate SMMAs with weight 2', function() {
+    var ema = new SMMA(2);
+    _.each(prices, function(p, i) {
+      ema.update(p);
+      expect(ema.result).to.equal(verified_smma2results[i]);
+    });
+  });
+
+  it('should correctly calculate EMAs with weight 12', function() {
+    var ema = new SMMA(12);
+    _.each(prices, function(p, i) {
+      ema.update(p);
+      expect(ema.result).to.equal(verified_smma12results[i]);
+    });
+  });
+
+  it('should correctly calculate EMAs with weight 26', function() {
+    var ema = new SMMA(26);
+    _.each(prices, function(p, i) {
+      ema.update(p);
+      expect(ema.result).to.equal(verified_smma26results[i]);
+    });
+  });
+});

--- a/test/indicators/smma.js
+++ b/test/indicators/smma.js
@@ -28,26 +28,26 @@ describe('indicators/SMMA', function() {
   var verified_smma26results = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 51.15384615384615, 49.84023668639053, 51.384842967683205, 52.75465669969539, 54.0333237497071, 55.76281129779529, 53.73347240172624, 54.35910807858292, 52.30683469094512, 51.33349489513954, 49.70528355301879, 51.33200341636422, 51.973080208042525, 50.32026943081012];
 
   it('should correctly calculate SMMAs with weight 2', function() {
-    var ema = new SMMA(2);
+    var smma = new SMMA(2);
     _.each(prices, function(p, i) {
-      ema.update(p);
-      expect(ema.result).to.equal(verified_smma2results[i]);
+      smma.update(p);
+      expect(smma.result).to.equal(verified_smma2results[i]);
     });
   });
 
-  it('should correctly calculate EMAs with weight 12', function() {
-    var ema = new SMMA(12);
+  it('should correctly calculate SMMAs with weight 12', function() {
+    var smma = new SMMA(12);
     _.each(prices, function(p, i) {
-      ema.update(p);
-      expect(ema.result).to.equal(verified_smma12results[i]);
+      smma.update(p);
+      expect(smma.result).to.equal(verified_smma12results[i]);
     });
   });
 
-  it('should correctly calculate EMAs with weight 26', function() {
-    var ema = new SMMA(26);
+  it('should correctly calculate SMMAs with weight 26', function() {
+    var smma = new SMMA(26);
     _.each(prices, function(p, i) {
-      ema.update(p);
-      expect(ema.result).to.equal(verified_smma26results[i]);
+      smma.update(p);
+      expect(smma.result).to.equal(verified_smma26results[i]);
     });
   });
 });


### PR DESCRIPTION
Part 1/2 of #759 

I'm going to split the pull request as this one is backwards compatible. The next part is not - it will replace the current RSI function with the one from the original study.

This means the patch version can be incremented for this specific PR, instead of a semver-minor.
Tests are included, however, it looked like the test suite is broken for this repository.
Anyway, I just added them in the same style as the tests for the other indicators.

The pre-calculated results are taken from my [own repository](https://github.com/wuhkuh/talib), which is documented and tested thoroughly. Sources used to determine the correct algorithm are documented, as well.