### PR TITLE
Batch the backtest with variation in parameters, result in CSV

### DIFF
--- a/labgekko.js
+++ b/labgekko.js
@@ -324,6 +324,16 @@ function start() {
 
 }
 
+// helper to store the evenutally detected
+// daterange.
+var setDateRange = function(from, to) {
+  config.backtest.daterange = {
+    from: moment.unix(from).utc().format(),
+    to: moment.unix(to).utc().format(),
+  };
+  util.setConfig(config);
+}
+
 if (config.backtest.daterange === 'scan') {
   scan((err, ranges) => {
     if(_.size(ranges) === 0)

--- a/labgekko.js
+++ b/labgekko.js
@@ -269,7 +269,8 @@ function newSimulation(cb) {
     function(report) {
       saveReport(report);
       var result=calulateResult(report);
-      log.info("Result="+result.toFixed(0)+" ("+((result>0) ? "Good deal !" :"Better than the market if positif")+")");
+      log.info();
+      log.info("Difference with marker ="+result.toFixed(0)+" ("+((result>0) ? "Good deal !" :"")+")");
       cb();
     });
 }
@@ -289,6 +290,7 @@ function printPatchedConfig() {
   for (var i=0;i<config.lab.values.length;++i) {
     log.info(config.lab.values[i].path+" = "+JSON.stringify(config.lab.values[i].value))
   }
+  log.info();
 }
 
 // -------------- Start the experience

--- a/labgekko.js
+++ b/labgekko.js
@@ -1,0 +1,352 @@
+console.log(`
+***********************
+****** LAB GEKKO ******
+***********************
+`);
+
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const util = require(__dirname + '/core/util');
+const moment = require('moment');
+const promisify = require('tiny-promisify');
+const pipelineRunner = promisify(require(__dirname + '/core/workers/pipeline/parent'));
+const log = require(__dirname + '/core/log');
+var scan = require(__dirname + '/core/tools/dateRangeScanner');
+
+const config = util.getConfig();
+const csvpath=config.lab.file
+
+const CSV_SEPARATOR=';';
+const debug=false; // To desactivate the launch of tests
+
+if (util.gekkoMode() != 'backtest')
+  util.die('Lab only with backtest');
+
+
+// Config variable to patch
+const patchs=config.lab.patchs
+// Extends simple loop, and invoke initialization
+for (var i=0;i<patchs.length;++i) {
+  var patch=patchs[i];
+  if ('loop' in patch) {
+    patch.exloop=[
+      "config.{} = "+patch.loop[0],
+      "config.{} "+patch.loop[1],
+      "config.{} = config.{} "+patch.loop[2]];
+  }
+  if (patch.exloop.length > 3) {
+    //log.debug(patch.exloop[3].replace(/{}/g,patch.path));
+    eval(patch.exloop[3].replace(/{}/g,patch.path));
+  }
+}
+// Set the default fields
+if (!('fields' in config.lab)) {
+  config.lab.fields=[
+    "method",
+    "exchange","currency","asset",
+    "candleSize","historySize",
+    "patchs",
+    "startTime","endTime","timespan",
+    "startPrice","endPrice","market",
+    "trades",
+    "startBalance","balance","profit","relativeProfit",
+    "relativeResult"
+  ];
+}
+
+/**
+ * Slide a dateRange with specific delta
+ * @param dateRange The dateRange to slide.
+ * @param number The number to add
+ * @param unit The unit to add.
+ */
+function slidingWindow(dateRange,number,unit) {
+  dateRange.from=moment(dateRange.from).add(number,unit).format('YYYY-MM-DD HH:mm:ss');
+  dateRange.to=moment(dateRange.to).add(number,unit).format('YYYY-MM-DD HH:mm:ss');
+}
+
+
+function startPipeline(config,onError,onExit) {
+  const id = (Math.random() + '').slice(3);
+  pipelineRunner('backtest', config, (err, event) => {
+    if (err) {
+      onError(err,event);
+    }
+
+    if (!event) {
+      return; // Crash may be
+    // } else if(event.type === 'trade') {
+    //   log.debug("Receive trade");
+    //   return;
+    // } else if (event.type === 'roundtrip') {
+    //   log.debug("Receive roundtrip");
+    //   return;
+    // } else if (event.type === 'update') {
+    //   log.debug("Receive update");
+    }  else {
+      if (event.report) {
+        onExit(event.report);
+      }
+      else {
+        console.log("unknown event");
+        console.dir(event);
+      }
+    }
+  });
+}
+
+function saveReportHeaders() {
+  if (!fs.existsSync(csvpath)) {
+    var headers="";
+    var fields=config.lab.fields;
+    for (var i=0;i<fields.length;++i) {
+      if (fields[i] === 'patchs') {
+        for (var j=0;j<config.lab.values.length;++j) {
+          headers=headers.concat(config.lab.values[j].path).concat(CSV_SEPARATOR)
+        }
+      }
+      else {
+        headers=headers.concat(fields[i]).concat(CSV_SEPARATOR)
+      }
+    }
+    headers=headers.concat('\n');
+
+    fs.writeFileSync(csvpath,headers);
+  }
+}
+
+function calulateResult(report) {
+  var marketDiff=report.endPrice-report.startPrice;
+  var balance=report.balance-report.startBalance;
+//  return result=(balance-marketDiff)/report.endPrice;
+  return result=(balance-marketDiff);
+}
+
+function saveReport(report) {
+  var CSV="";
+  var fields=config.lab.fields;
+  for (var i=0;i<fields.length;++i) {
+    var field=fields[i];
+    if (field === 'method') {
+      CSV=CSV.concat(JSON.stringify(config.tradingAdvisor.method)).concat(CSV_SEPARATOR)
+    } else if (field == 'exchange') {
+      CSV=CSV.concat(config.watch.exchange).concat(CSV_SEPARATOR);
+    } else if (field == 'currency') {
+      CSV=CSV.concat(config.watch.currency).concat(CSV_SEPARATOR);
+    } else if (field == 'asset') {
+      CSV=CSV.concat(config.watch.asset).concat(CSV_SEPARATOR);
+    } else if (field == 'candleSize') {
+      CSV=CSV.concat(config.tradingAdvisor.candleSize).concat(CSV_SEPARATOR);
+    } else if (field == 'historySize') {
+      CSV=CSV.concat(config.tradingAdvisor.historySize).concat(CSV_SEPARATOR);
+    } else if (field === 'patchs') {
+      for (var j=0;j<config.lab.values.length;++j) {
+        CSV=CSV.concat(JSON.stringify(config.lab.values[j].value)).concat(CSV_SEPARATOR)
+      }
+    }
+    else if ((field === 'market') || (field === 'relativeProfit')) {
+      if (!report) CSV=CSV.concat("ERROR").concat(CSV_SEPARATOR)
+      else CSV=CSV.concat((report[field]/100).toFixed(4)).concat(CSV_SEPARATOR) // %
+    }
+    else if (field === 'relativeResult') {
+      if (!report) CSV=CSV.concat("ERROR").concat(CSV_SEPARATOR)
+      else CSV=CSV.concat(calulateResult(report).toFixed(4)).concat(CSV_SEPARATOR)
+    } else {
+      if (!report) CSV=CSV.concat("ERROR").concat(CSV_SEPARATOR)
+      else CSV=CSV.concat(JSON.stringify(report[field])).concat(CSV_SEPARATOR)
+    }
+  }
+  CSV=CSV.concat('\n');
+  saveReportHeaders();
+  fs.appendFileSync(csvpath, CSV);
+}
+
+function loopVariablesAsync(index, func, callback) {
+  var done = false;
+  if (index<patchs.length) {
+    var patch = patchs[index];
+    //log.debug(patch.loop[0].replace(/{}/g,patch.path)); // Set
+    try {
+      eval(patch.exloop[0].replace(/{}/g,patch.path)); // Set
+    } catch (e) {
+      log.error("Error when eval "+patch.exloop[0]);
+      return;
+    }
+    log.debug("")
+  }
+  var loop = {
+    next: function() {
+      if (done) {
+        return;
+      }
+      var variable = patchs[index];
+      // Test
+      try {
+        var rc=eval(variable.exloop[1].replace(/{}/g,variable.path)); // Check
+      } catch (e) {
+        log.error("Error when eval "+patch.exloop[0]);
+        return;
+      }
+      //log.debug(eval(patch.loop[1].replace(/{}/g,patch.path))+" == " +rc);
+      if (rc) {
+        func({
+          next: function() {
+            //log.debug(patch.loop[2].replace(/{}/g,patch.path));
+            try {
+              eval(variable.exloop[2].replace(/{}/g,variable.path)); // Increment
+            } catch(e) {
+              log.error("Error when eval "+patch.exloop[0]);
+              return;
+            }
+            loop.next();
+          }
+        },index);
+      } else {
+        done = true;
+        callback();
+      }
+    },
+
+    break: function() {
+      done = true;
+      callback();
+    }
+  };
+  loop.next();
+  return loop;
+}
+
+// Create an invoke a recursive async loop
+function loopAllPatchsAsync(body,done) {
+
+  var nextsCallBack=[];
+
+  for (var i=0;i<patchs.length-1;++i) {
+    nextsCallBack.push(function(loop,index) {
+      loopVariablesAsync(
+        index+1,
+        nextsCallBack[index+1],
+        function() {
+          // End inner loop
+          loop.next()
+        }
+      )
+    });
+  }
+  nextsCallBack.push(function(loop,index)  { body(loop); });
+
+  if (patchs.length>0 && config.lab.enabled) {
+    loopVariablesAsync(0,
+      nextsCallBack[0],
+      function() {
+        // End outer loop
+        done()
+      })
+  }
+  else {
+    const pipeline = require(util.dirs().core + 'pipeline');
+    pipeline({
+      config: config,
+      mode: 'backtest'
+    });
+  }
+}
+
+var numberOfTest=0;
+
+function newSimulation(cb) {
+  log.info();
+  log.info("*********************** New Back Test ("+ ++numberOfTest +") ***********************");
+  savePatchedConfig();
+  printPatchedConfig();
+  startPipeline(config,
+    function(err,event) {
+      saveReport(null);
+      log.info("Impossible to execute this scenario");
+      cb();
+    },
+    function(report) {
+      saveReport(report);
+      var result=calulateResult(report);
+      log.info("Result="+result.toFixed(0)+" ("+((result>0) ? "Good deal !" :"Better than the market if positif")+")");
+      cb();
+    });
+}
+
+function savePatchedConfig() {
+  config.lab.values=[]
+  for (var i=0;i<patchs.length;++i) {
+    config.lab.values.push({
+      path:patchs[i].path,
+      value:eval("config."+patchs[i].path)
+    })
+  }
+
+}
+
+function printPatchedConfig() {
+  for (var i=0;i<config.lab.values.length;++i) {
+    log.info(config.lab.values[i].path+" = "+JSON.stringify(config.lab.values[i].value))
+  }
+}
+
+// -------------- Start the experience
+// Reset file
+function resetFile() {
+  if (fs.existsSync(csvpath)) fs.unlinkSync(csvpath);
+  var dir=path.dirname(csvpath);
+  fs.existsSync(dir) || fs.mkdirSync(dir);
+}
+
+// And start the recursive loop
+function start() {
+  resetFile();
+  var startTime=Date.now();
+  loopAllPatchsAsync(function(loop) {
+      if (debug) {
+        savePatchedConfig();
+        printPatchedConfig();
+        console.log("Simule... ");
+        loop.next();
+        return;
+      }
+      newSimulation(function(result) {
+        loop.next(); // For cycle could continue
+      })},
+    function(){
+      log.info('All simulations are done. The results are in '+config.lab.file+
+        "("+(moment.duration(Date.now()-startTime).humanize())+")");
+    }
+  );
+
+}
+
+if (config.backtest.daterange === 'scan') {
+  scan((err, ranges) => {
+    if(_.size(ranges) === 0)
+      util.die('No history found for this market', true);
+
+    if(_.size(ranges) === 1) {
+      var r = _.first(ranges);
+      log.info('Gekko was able to find a single daterange in the locally stored history:');
+      log.info('\t', 'from:', moment.unix(r.from).utc().format('YYYY-MM-DD HH:mm:ss'));
+      log.info('\t', 'to:', moment.unix(r.to).utc().format('YYYY-MM-DD HH:mm:ss'));
+
+      setDateRange(r.from, r.to);
+      start();
+      return;
+    }
+
+    log.error(
+      'Gekko detected multiple dateranges in the locally stored history.',
+      'Please set \'config.backtest.from\' and \'config.backtest.to\',',
+      'with the daterange you are interested in testing.'
+    );
+    return
+  });
+}
+else
+  start();
+
+

--- a/labs/.gitignore
+++ b/labs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/sample-config.js
+++ b/sample-config.js
@@ -33,7 +33,7 @@ config.watch = {
 config.tradingAdvisor = {
   enabled: true,
   method: 'MACD',
-  candleSize: 1,
+  candleSize: 60, // FIXME: 1
   historySize: 3,
   adapter: 'sqlite',
   talib: {
@@ -435,6 +435,74 @@ config.importer = {
     from: "2016-01-01 00:00:00"
   }
 }
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//                       CONFIGURING LABS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// To use the labs, indicate all the variables to change for each firing
+// with a 'for' loop design.
+// For each variable, add an object in patchs with
+// - 'path' with the name of the variable (in config)
+// - 'loop' with 3 simple pattern
+//    [0] : to initialise the parameter (with '0', use to execute '{} = 0')
+//    [1] : to check the end of the loop (with '< 3' use to execute '{} < 3'
+//    [2] : to increment the parameter (with '+ 1' use to execute '{} = {} + 1'
+// - or 'exloop' with extended pattern like
+// {
+//    path:"backtest.daterange",
+//    exloop:[
+//       '',
+//       'moment(config.{}.to).isBefore("2017-03-07")',
+//       'slideWindow(config.{},1, "day")'
+//    ],
+// }
+//
+// All the results are saved in 'file' with CSV format.
+// To start, use 'node labgekko --config ...' in place of 'node gekko --config ...'
+config.lab={
+  enabled:true,
+  file:"labs/"+config.tradingAdvisor.method+".csv",
+  // Can be omitted or reorders
+  fields:[
+    "method",
+    // "exchange","currency","asset",
+    // "candleSize","historySize",
+    "patchs",
+    // "startTime","endTime","timespan",
+    // "startPrice","endPrice",
+    "market",
+    "trades",
+    // "startBalance","balance","profit",
+    "relativeProfit",
+    "relativeResult"
+  ],
+  patchs:[
+    { // 10
+      path: "MACD.short",
+      loop: ["5", "<= 15", "+ 5"], // Normal:10
+    },
+    { // 21
+      path: "MACD.long",
+      loop: ["16", "<= 26", "+ 5"], // Normal:21
+    },
+    { // 9
+      path: "MACD.signal",
+      loop: ["8", "<= 10", "+ 1"], // Normal:9
+    },
+    // Sample of complex loop
+    // {
+    //   path:"backtest.daterange",
+    //   exloop:[
+    //     'config.{}={from:"2016-01-01", to: "2016-04-01"}',
+    //     'moment(config.{}.to).isBefore("2017-12-15")',
+    //     'slidingWindow(config.{},1, "month")',
+    //     '// require nothing in global scope',
+    //   ],
+    // },
+  ],
+}
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // set this to true if you understand that Gekko will
 // invest according to how you configured the indicators.

--- a/sample-config.js
+++ b/sample-config.js
@@ -440,7 +440,7 @@ config.importer = {
 //                       CONFIGURING LABS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// To use the labs, indicate all the variables to change for each firing
+// To use the labs, indicate all the variables to change for each launch
 // with a 'for' loop design.
 // For each variable, add an object in patchs with
 // - 'path' with the name of the variable (in config)
@@ -452,18 +452,19 @@ config.importer = {
 // {
 //    path:"backtest.daterange",
 //    exloop:[
-//       '',
+//       '// init',
 //       'moment(config.{}.to).isBefore("2017-03-07")',
-//       'slideWindow(config.{},1, "day")'
+//       'slideWindow(config.{},1, "day")',
+//       '// const x=require(...)
 //    ],
 // }
 //
 // All the results are saved in 'file' with CSV format.
-// To start, use 'node labgekko --config ...' in place of 'node gekko --config ...'
+// To start, use 'node labgekko --backtest --config ...' in place of 'node gekko --backtest --config ...'
 config.lab={
   enabled:true,
   file:"labs/"+config.tradingAdvisor.method+".csv",
-  // Can be omitted or reorders
+  // Fields to add in CSV. Can be omitted or reorders
   fields:[
     "method",
     // "exchange","currency","asset",
@@ -477,6 +478,7 @@ config.lab={
     "relativeProfit",
     "relativeResult"
   ],
+  // Lists of modification to apply in config.
   patchs:[
     { // 10
       path: "MACD.short",
@@ -490,7 +492,7 @@ config.lab={
       path: "MACD.signal",
       loop: ["8", "<= 10", "+ 1"], // Normal:9
     },
-    // Sample of complex loop
+    // Sample of complex loop with sliding window
     // {
     //   path:"backtest.daterange",
     //   exloop:[


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This extension launch many times a back test, with different parameters.
All the results are added in a CSV file. It's easy to try different parameters values for the same data, or
to check a strategy in a sliding windows.

See `config.lab` in `sample-config.js`
To start, check the backtest
`node gekko --config <...> --backtest`
then use 
`node labgekko --config <...> --backtest`.
```
config.lab={
  enabled:true,
  file:"labs/"+config.tradingAdvisor.method+".csv",
  // Fields to add in CSV. Can be omitted or reorders
  fields:[
    "method", "exchange","currency","asset",
    "candleSize","historySize",
    "patchs",
    "startTime","endTime","timespan",
    "startPrice","endPrice","market","trades",
    "startBalance","balance","profit",
    "relativeProfit", "relativeResult"
  ],
  // Lists of modification to apply in config.
  patchs:[
    { 
      path: "MACD.short",
      loop: ["5", "<= 15", "+ 5"], // Normal:10
    },
    { 
      path: "MACD.long",
      loop: ["16", "<= 26", "+ 5"], // Normal:21
    },
    { 
      path: "MACD.signal",
      loop: ["8", "<= 10", "+ 1"], // Normal:9
    },
    {
      path:"backtest.daterange",
      exloop:[
        'config.{}={from:"2016-01-01", to: "2016-04-01"}',
        'moment(config.{}.to).isBefore("2017-12-15")',
        'slidingWindow(config.{},1, "month")',
        '// require nothing in global scope',
      ],
    },
  ],
}
```

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
It's possible to add a new mode and remove the specific `labgekko`.