### PR TITLE
Inject config into his strategy

### DIFF
--- a/docs/strategies/creating_a_strategy.md
+++ b/docs/strategies/creating_a_strategy.md
@@ -187,12 +187,10 @@ You can create configurable parameters for your method which allows you to adjus
 
 And in your method you can use them again (for example to pass to an indicator):
 
-    // in the init:
-    var config = require('../core/util.js').getConfig();
-    this.settings = config.custom;
-
     // anywhere in your code:
     this.settings.my_custom_setting; // is now 10
+
+___The name of your configuration must be the same as the name of the strategy___
 
 ### Tool libraries
 

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -75,14 +75,15 @@ var Indicators = {
 var allowedIndicators = _.keys(Indicators);
 var allowedTalibIndicators = _.keys(talib);
 
-var Base = function() {
+var Base = function(settings) {
   _.bindAll(this);
 
   // properties
   this.age = 0;
   this.processedTicks = 0;
   this.setup = false;
-
+  this.settings = settings;
+  this.tradingAdvisor = config.tradingAdvisor;
   // defaults
   this.requiredHistory = 0;
   this.priceValue = 'close';

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -55,12 +55,16 @@ Actor.prototype.setupTradingMethod = function() {
     Consultant.prototype[name] = fn;
   });
 
-  this.method = new Consultant;
+  if(config[this.methodName]) {
+    var tradingSettings = config[this.methodName];
+  }
+
+  this.method = new Consultant(tradingSettings);
   this.method
     .on('advice', this.relayAdvice);
 
   this.batcher
-    .on('candle', this.processCustomCandle)
+    .on('candle', this.processCustomCandle);
 }
 
 // HANDLERS

--- a/strategies/CCI.js
+++ b/strategies/CCI.js
@@ -2,11 +2,6 @@
 var _ = require('lodash');
 var log = require('../core/log.js');
 
-// configuration
-var config = require('../core/util.js').getConfig();
-var settings = config.CCI;
-var pposettings = config.PPO;
-
 // let's create our own method
 var method = {};
 
@@ -22,15 +17,15 @@ method.init = function() {
     persisted: false,
     adviced: false
   };
-  this.historySize = config.tradingAdvisor.historySize;
+  this.historySize = this.tradingAdvisor.historySize;
   this.ppoadv = 'none';
-  this.uplevel = settings.thresholds.up;
-  this.downlevel = settings.thresholds.down;
-  this.persisted = settings.thresholds.persistence;
+  this.uplevel = this.settings.thresholds.up;
+  this.downlevel = this.settings.thresholds.down;
+  this.persisted = this.settings.thresholds.persistence;
 
   // log.debug("CCI started with:\nup:\t", this.uplevel, "\ndown:\t", this.downlevel, "\npersistence:\t", this.persisted);
   // define the indicators we need
-  this.addIndicator('cci', 'CCI', settings);
+  this.addIndicator('cci', 'CCI', this.settings);
 }
 
 // what happens on every new candle?
@@ -59,7 +54,7 @@ method.log = function() {
 }
 
 /*
- * 
+ *
  */
 method.check = function(candle) {
 
@@ -120,7 +115,7 @@ method.check = function(candle) {
             }
             this.advice();
         }
-                
+
     } else {
         this.advice();
     }

--- a/strategies/DEMA.js
+++ b/strategies/DEMA.js
@@ -2,10 +2,6 @@
 var _ = require('lodash');
 var log = require('../core/log.js');
 
-// configuration
-var config = require('../core/util.js').getConfig();
-var settings = config.DEMA;
-
 // let's create our own method
 var method = {};
 
@@ -14,10 +10,10 @@ method.init = function() {
   this.name = 'DEMA';
 
   this.currentTrend;
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
-  this.addIndicator('dema', 'DEMA', settings);
+  this.addIndicator('dema', 'DEMA', this.settings);
 }
 
 // what happens on every new candle?
@@ -44,7 +40,7 @@ method.check = function(candle) {
 
   var message = '@ ' + price.toFixed(8) + ' (' + diff.toFixed(5) + ')';
 
-  if(diff > settings.thresholds.up) {
+  if(diff > this.settings.thresholds.up) {
     log.debug('we are currently in uptrend', message);
 
     if(this.currentTrend !== 'up') {
@@ -53,7 +49,7 @@ method.check = function(candle) {
     } else
       this.advice();
 
-  } else if(diff < settings.thresholds.down) {
+  } else if(diff < this.settings.thresholds.down) {
     log.debug('we are currently in a downtrend', message);
 
     if(this.currentTrend !== 'down') {

--- a/strategies/MACD.js
+++ b/strategies/MACD.js
@@ -1,5 +1,5 @@
 /*
-  
+
   MACD - DJM 31/12/2013
 
   (updated a couple of times since, check git history)
@@ -9,10 +9,6 @@
 // helpers
 var _ = require('lodash');
 var log = require('../core/log.js');
-
-// configuration
-var config = require('../core/util.js').getConfig();
-var settings = config.MACD;
 
 // let's create our own method
 var method = {};
@@ -33,10 +29,10 @@ method.init = function() {
 
   // how many candles do we need as a base
   // before we can start giving advice?
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
-  this.addIndicator('macd', 'MACD', settings);
+  this.addIndicator('macd', 'MACD', this.settings);
 }
 
 // what happens on every new candle?
@@ -64,7 +60,7 @@ method.log = function() {
 method.check = function() {
   var macddiff = this.indicators.macd.result;
 
-  if(macddiff > settings.thresholds.up) {
+  if(macddiff > this.settings.thresholds.up) {
 
     // new trend detected
     if(this.trend.direction !== 'up')
@@ -80,7 +76,7 @@ method.check = function() {
 
     log.debug('In uptrend since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -89,7 +85,7 @@ method.check = function() {
     } else
       this.advice();
 
-  } else if(macddiff < settings.thresholds.down) {
+  } else if(macddiff < this.settings.thresholds.down) {
 
     // new trend detected
     if(this.trend.direction !== 'down')
@@ -105,7 +101,7 @@ method.check = function() {
 
     log.debug('In downtrend since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -120,9 +116,9 @@ method.check = function() {
 
     // we're not in an up nor in a downtrend
     // but for now we ignore sideways trends
-    // 
+    //
     // read more @link:
-    // 
+    //
     // https://github.com/askmike/gekko/issues/171
 
     // this.trend = {

--- a/strategies/PPO.js
+++ b/strategies/PPO.js
@@ -1,5 +1,5 @@
 /*
-  
+
   PPO - cykedev 15/01/2014
 
   (updated a couple of times since, check git history)
@@ -9,10 +9,6 @@
 // helpers
 var _ = require('lodash');
 var log = require('../core/log');
-
-// configuration
-var config = require('../core/util').getConfig();
-var settings = config.PPO;
 
 // let's create our own method
 var method = {};
@@ -26,10 +22,10 @@ method.init = function() {
    adviced: false
   };
 
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
-  this.addIndicator('ppo', 'PPO', settings);
+  this.addIndicator('ppo', 'PPO', this.settings);
 }
 
 // what happens on every new candle?
@@ -37,7 +33,7 @@ method.update = function(candle) {
   // nothing!
 }
 
-// for debugging purposes log the last 
+// for debugging purposes log the last
 // calculated parameters.
 method.log = function() {
   var digits = 8;
@@ -57,7 +53,7 @@ method.log = function() {
   log.debug('\t', 'machist:', (macd - macdSignal).toFixed(digits));
   log.debug('\t', 'ppo:', result.toFixed(digits));
   log.debug('\t', 'pposignal:', ppoSignal.toFixed(digits));
-  log.debug('\t', 'ppohist:', (result - ppoSignal).toFixed(digits));  
+  log.debug('\t', 'ppohist:', (result - ppoSignal).toFixed(digits));
 }
 
 method.check = function(candle) {
@@ -75,7 +71,7 @@ method.check = function(candle) {
   // if it is it should move there
   var ppoHist = result - ppoSignal;
 
-  if(ppoHist > settings.thresholds.up) {
+  if(ppoHist > this.settings.thresholds.up) {
 
     // new trend detected
     if(this.trend.direction !== 'up')
@@ -90,7 +86,7 @@ method.check = function(candle) {
 
     log.debug('In uptrend since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -98,8 +94,8 @@ method.check = function(candle) {
       this.advice('long');
     } else
       this.advice();
-    
-  } else if(ppoHist < settings.thresholds.down) {
+
+  } else if(ppoHist < this.settings.thresholds.down) {
 
     // new trend detected
     if(this.trend.direction !== 'down')
@@ -114,7 +110,7 @@ method.check = function(candle) {
 
     log.debug('In downtrend since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -130,9 +126,9 @@ method.check = function(candle) {
 
     // we're not in an up nor in a downtrend
     // but for now we ignore sideways trends
-    // 
+    //
     // read more @link:
-    // 
+    //
     // https://github.com/askmike/gekko/issues/171
 
     // this.trend = {

--- a/strategies/RSI.js
+++ b/strategies/RSI.js
@@ -1,5 +1,5 @@
 /*
-  
+
   RSI - cykedev 14/02/2014
 
   (updated a couple of times since, check git history)
@@ -8,9 +8,6 @@
 // helpers
 var _ = require('lodash');
 var log = require('../core/log.js');
-
-var config = require('../core/util.js').getConfig();
-var settings = config.RSI;
 
 var RSI = require('./indicators/RSI.js');
 
@@ -28,13 +25,13 @@ method.init = function() {
     adviced: false
   };
 
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
-  this.addIndicator('rsi', 'RSI', settings);
+  this.addIndicator('rsi', 'RSI', this.settings);
 }
 
-// for debugging purposes log the last 
+// for debugging purposes log the last
 // calculated parameters.
 method.log = function(candle) {
   var digits = 8;
@@ -49,7 +46,7 @@ method.check = function() {
   var rsi = this.indicators.rsi;
   var rsiVal = rsi.rsi;
 
-  if(rsiVal > settings.thresholds.high) {
+  if(rsiVal > this.settings.thresholds.high) {
 
     // new trend detected
     if(this.trend.direction !== 'high')
@@ -64,7 +61,7 @@ method.check = function() {
 
     log.debug('In high since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -72,8 +69,8 @@ method.check = function() {
       this.advice('short');
     } else
       this.advice();
-    
-  } else if(rsiVal < settings.thresholds.low) {
+
+  } else if(rsiVal < this.settings.thresholds.low) {
 
     // new trend detected
     if(this.trend.direction !== 'low')
@@ -88,7 +85,7 @@ method.check = function() {
 
     log.debug('In low since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {

--- a/strategies/StochRSI.js
+++ b/strategies/StochRSI.js
@@ -1,5 +1,5 @@
 /*
-  
+
   StochRSI - SamThomp 11/06/2014
 
   (updated by askmike) @ 30/07/2016
@@ -9,9 +9,6 @@
 var _ = require('lodash');
 var log = require('../core/log.js');
 
-var config = require('../core/util.js').getConfig();
-var settings = config.StochRSI;
-
 var RSI = require('./indicators/RSI.js');
 
 // let's create our own method
@@ -19,7 +16,7 @@ var method = {};
 
 // prepare everything our method needs
 method.init = function() {
-	this.interval = settings.interval;
+	this.interval = this.settings.interval;
 
   this.trend = {
     direction: 'none',
@@ -51,7 +48,7 @@ method.update = function(candle) {
 	this.stochRSI = ((this.rsi - this.lowestRSI) / (this.highestRSI - this.lowestRSI)) * 100;
 }
 
-// for debugging purposes log the last 
+// for debugging purposes log the last
 // calculated parameters.
 method.log = function() {
   var digits = 8;
@@ -64,7 +61,7 @@ method.log = function() {
 }
 
 method.check = function() {
-	if(this.stochRSI > settings.thresholds.high) {
+	if(this.stochRSI > this.settings.thresholds.high) {
 		// new trend detected
 		if(this.trend.direction !== 'high')
 			this.trend = {
@@ -78,7 +75,7 @@ method.check = function() {
 
 		log.debug('In high since', this.trend.duration, 'candle(s)');
 
-		if(this.trend.duration >= settings.thresholds.persistence)
+		if(this.trend.duration >= this.settings.thresholds.persistence)
 			this.trend.persisted = true;
 
 		if(this.trend.persisted && !this.trend.adviced) {
@@ -86,8 +83,8 @@ method.check = function() {
 			this.advice('short');
 		} else
 			this.advice();
-		
-	} else if(this.stochRSI < settings.thresholds.low) {
+
+	} else if(this.stochRSI < this.settings.thresholds.low) {
 
 		// new trend detected
 		if(this.trend.direction !== 'low')
@@ -102,7 +99,7 @@ method.check = function() {
 
 		log.debug('In low since', this.trend.duration, 'candle(s)');
 
-		if(this.trend.duration >= settings.thresholds.persistence)
+		if(this.trend.duration >= this.settings.thresholds.persistence)
 			this.trend.persisted = true;
 
 		if(this.trend.persisted && !this.trend.adviced) {

--- a/strategies/TSI.js
+++ b/strategies/TSI.js
@@ -2,9 +2,6 @@
 var _ = require('lodash');
 var log = require('../core/log.js');
 
-var config = require('../core/util.js').getConfig();
-var settings = config.TSI;
-
 var TSI = require('./indicators/TSI.js');
 
 // let's create our own method
@@ -21,13 +18,13 @@ method.init = function() {
     adviced: false
   };
 
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
-  this.addIndicator('tsi', 'TSI', settings);
+  this.addIndicator('tsi', 'TSI', this.settings);
 }
 
-// for debugging purposes log the last 
+// for debugging purposes log the last
 // calculated parameters.
 method.log = function(candle) {
   var digits = 8;
@@ -42,7 +39,7 @@ method.check = function() {
   var tsi = this.indicators.tsi;
   var tsiVal = tsi.tsi;
 
-  if(tsiVal > settings.thresholds.high) {
+  if(tsiVal > this.settings.thresholds.high) {
 
     // new trend detected
     if(this.trend.direction !== 'high')
@@ -57,7 +54,7 @@ method.check = function() {
 
     log.debug('In high since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -65,8 +62,8 @@ method.check = function() {
       this.advice('short');
     } else
       this.advice();
-    
-  } else if(tsiVal < settings.thresholds.low) {
+
+  } else if(tsiVal < this.settings.thresholds.low) {
 
     // new trend detected
     if(this.trend.direction !== 'low')
@@ -81,7 +78,7 @@ method.check = function() {
 
     log.debug('In low since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {

--- a/strategies/UO.js
+++ b/strategies/UO.js
@@ -2,9 +2,6 @@
 var _ = require('lodash');
 var log = require('../core/log.js');
 
-var config = require('../core/util.js').getConfig();
-var settings = config.UO;
-
 var UO = require('./indicators/UO.js');
 
 // let's create our own method
@@ -21,13 +18,13 @@ method.init = function() {
     adviced: false
   };
 
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
-  this.addIndicator('uo', 'UO', settings);
+  this.addIndicator('uo', 'UO', this.settings);
 }
 
-// for debugging purposes log the last 
+// for debugging purposes log the last
 // calculated parameters.
 method.log = function(candle) {
   var digits = 8;
@@ -42,7 +39,7 @@ method.check = function() {
   var uo = this.indicators.uo;
   var uoVal = uo.uo;
 
-  if(uoVal > settings.thresholds.high) {
+  if(uoVal > this.settings.thresholds.high) {
 
     // new trend detected
     if(this.trend.direction !== 'high')
@@ -57,7 +54,7 @@ method.check = function() {
 
     log.debug('In high since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {
@@ -65,8 +62,8 @@ method.check = function() {
       this.advice('short');
     } else
       this.advice();
-    
-  } else if(uoVal < settings.thresholds.low) {
+
+  } else if(uoVal < this.settings.thresholds.low) {
 
     // new trend detected
     if(this.trend.direction !== 'low')
@@ -81,7 +78,7 @@ method.check = function() {
 
     log.debug('In low since', this.trend.duration, 'candle(s)');
 
-    if(this.trend.duration >= settings.thresholds.persistence)
+    if(this.trend.duration >= this.settings.thresholds.persistence)
       this.trend.persisted = true;
 
     if(this.trend.persisted && !this.trend.adviced) {

--- a/strategies/talib-macd.js
+++ b/strategies/talib-macd.js
@@ -1,11 +1,8 @@
 // If you want to use your own trading methods you can
 // write them here. For more information on everything you
 // can use please refer to this document:
-// 
+//
 // https://github.com/askmike/gekko/blob/stable/docs/trading_methods.md
-
-var config = require('../core/util.js').getConfig();
-var settings = config['talib-macd'];
 
 // Let's create our own method
 var method = {};
@@ -21,9 +18,9 @@ method.init = function() {
 
   // how many candles do we need as a base
   // before we can start giving advice?
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
-  var customMACDSettings = settings.parameters;
+  var customMACDSettings = this.settings.parameters;
 
   // define the indicators we need
   this.addTalibIndicator('mymacd', 'macd', customMACDSettings);
@@ -47,11 +44,11 @@ method.check = function(candle) {
   var result = this.talibIndicators.mymacd.result;
   var macddiff = result['outMACD'] - result['outMACDSignal'];
 
-  if(settings.thresholds.down > macddiff && this.trend !== 'short') {
+  if(this.settings.thresholds.down > macddiff && this.trend !== 'short') {
     this.trend = 'short';
     this.advice('short');
 
-  } else if(settings.thresholds.up < macddiff && this.trend !== 'long'){
+  } else if(this.settings.thresholds.up < macddiff && this.trend !== 'long'){
     this.trend = 'long';
     this.advice('long');
 

--- a/strategies/varPPO.js
+++ b/strategies/varPPO.js
@@ -21,7 +21,7 @@ method.init = function() {
    adviced: false
   };
 
-  this.requiredHistory = config.tradingAdvisor.historySize;
+  this.requiredHistory = this.tradingAdvisor.historySize;
 
   // define the indicators we need
   this.addIndicator('ppo', 'PPO', config.PPO);
@@ -33,7 +33,7 @@ method.update = function(candle) {
   // nothing!
 }
 
-// for debugging purposes log the last 
+// for debugging purposes log the last
 // calculated parameters.
 method.log = function(candle) {
   var digits = 8;
@@ -86,7 +86,7 @@ method.check = function() {
       this.advice('long');
     } else
       this.advice();
-    
+
   } else if(value > thresholds.high) {
 
     // new trend detected
@@ -118,9 +118,9 @@ method.check = function() {
 
     // we're not in an up nor in a downtrend
     // but for now we ignore sideways trends
-    // 
+    //
     // read more @link:
-    // 
+    //
     // https://github.com/askmike/gekko/issues/171
 
     // this.trend = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: To avoid injecting all the config file and then filter it by the strategy name, I did a little change to inject it directly through the Base strategy. This modification permits you to access to your `settings` configuration and also the `tradingAdvisor` configuration.

* **What is the current behavior?** (You can also link to an open issue here)
Today, we have to do 
```
var config = require('../core/util.js').getConfig();
var settings = config.UO;
```

* **What is the new behavior (if this is a feature change)?**
With this PR, we could do 
```
method.init = function() {
  this.settings // Get the strategy settings
  this.tradingAdvisor // Get the trading advisor 
}
```

* **Other information**:
How do I do the test? I did not see any tests for the strategies, do you have some advice because I'm not totally confident with the library