### PR TITLE
color coded profit & loss in roundtrip table

### DIFF
--- a/web/vue/src/components/backtester/result/roundtripTable.vue
+++ b/web/vue/src/components/backtester/result/roundtripTable.vue
@@ -17,8 +17,12 @@
           td {{ diff(rt.duration) }}
           td {{ round(rt.entryBalance) }}
           td {{ round(rt.exitBalance) }}
-          td {{ round(rt.pnl) }}
-          td {{ round(rt.profit) }}
+          template(v-if="Math.sign(rt.pnl)===-1")
+            td.loss {{ Math.sign(rt.pnl)*rt.pnl.toFixed(2) }}
+            td.loss {{ rt.profit.toFixed(2) }}%
+          template(v-else)
+            td.profit {{ rt.pnl.toFixed(2) }}
+            td.profit {{ rt.profit.toFixed(2) }}%
     div(v-if='!roundtrips.length')
       p Not enough data to display
 </template>
@@ -53,6 +57,15 @@ export default {
 .roundtrips table td {
   border: 1px solid #c6cbd1;
   padding: 8px 12px;
+}
+
+.roundtrips table td.loss {
+  color: red;
+  text-align: right;
+}
+.roundtrips table td.profit {
+  color: green;
+  text-align: right;
 }
 
 .roundtrips table tr:nth-child(2n) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
better readability of P&L and Profit column


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**
right-aligned, red for losses, green for profits, added % sign, limit to 2 fraction digits.
also removed the -(minus) sign for losses, since a negative loss would actually be a profit,
not sure if this appeals to everyone though.

here's how it looks now:
![bildschirmfoto 2017-09-07 um 21 02 47](https://user-images.githubusercontent.com/324694/30180976-00168a48-9412-11e7-9343-1d9388492cfa.png)


* **Other information**:
