### PR TITLE
Fix a typo in the parameter list for the example UO strategy

### DIFF
--- a/config/strategies/UO.toml
+++ b/config/strategies/UO.toml
@@ -12,5 +12,5 @@ period = 28
 
 [thresholds]
 low = 30
-hight = 70
+high = 70
 persistence = 1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The example UO strategy doesn't really work because there is a typo.  "hight" should be "high".


* **What is the new behavior (if this is a feature change)?**
I removed the extra "t" so that people would be able to play around with the example settings like normal.


* **Other information**:
