### PR TITLE
[Bugfix] talib macdfix option does not match the requires one

### DIFF
--- a/core/talib.js
+++ b/core/talib.js
@@ -588,7 +588,7 @@ methods.macdext = {
 }
 
 methods.macdfix = {
-    requires: ['SignalPeriod'],
+    requires: ['optInSignalPeriod'],
     create: (params) => {
         verifyParams('macdfix', params);
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
Talib MACDFIX does not work because of the requires option (`SignalPeriod`) does not match the used option (`optInSignalPeriod`)


* **What is the new behavior (if this is a feature change)?**
Fix the bug


* **Other information**:
