### PR TITLE
Batch the backtest with variation in parameters, result in CSV (new pull request from develop branch)

### DIFF
--- a/gekko.iml
+++ b/gekko.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/core" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/exchanges" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/importers" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/plugins" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/strategies" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/web" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/labgekko.js
+++ b/labgekko.js
@@ -1,0 +1,389 @@
+/**
+ * @autor Philippe Prados
+ */
+console.log(`
+***********************
+****** LAB GEKKO ******
+***********************
+`);
+
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const util = require(__dirname + '/core/util');
+const moment = require('moment');
+const promisify = require('tiny-promisify');
+const pipelineRunner = promisify(require(__dirname + '/core/workers/pipeline/parent'));
+const log = require(__dirname + '/core/log');
+const scan = require(__dirname + '/core/tools/dateRangeScanner');
+
+const config = util.getConfig();
+const csvpath=config.lab.file;
+
+const CSV_SEPARATOR=';';
+const debug=false; // To desactivate the launch of tests
+
+if (util.gekkoMode() !== 'backtest')
+  util.die('Lab only with backtest');
+
+// Config variable to patch
+const patchs=config.lab.patchs;
+const loopContext={};
+
+// Extends simple loop, and invoke initialization
+for (var i=0;i<patchs.length;++i) {
+  const patch=patchs[i];
+  if ('loop' in patch) {
+    patch.exloop=[
+      "config.{} = "+patch.loop[0],
+      "config.{} "+patch.loop[1],
+      "config.{} = config.{} "+patch.loop[2]];
+  }
+}
+// Set the default fields
+if (!('fields' in config.lab)) {
+  config.lab.fields=[
+    "method",
+    "exchange","currency","asset",
+    "candleSize","historySize",
+    "patchs",
+    "startTime","endTime","timespan",
+    "startPrice","endPrice","market",
+    "trades",
+    "startBalance","balance","profit","relativeProfit",
+    "relativeResult"
+  ];
+}
+
+loopContext.init=function() {
+  for (var i=0;i<patchs.length;++i) {
+    var patch=patchs[i];
+    if (patch.exloop.length > 3) {
+      //log.debug(patch.exloop[3].replace(/{}/g,patch.path));
+      try {
+        eval(patch.exloop[3].replace(/{}/g,patch.path));
+      } catch (e) {
+        log.error("Error when eval '"+patch.exloop[3]+"'",e);
+        return;
+      }
+    }
+  }
+};
+
+loopContext.init();
+
+/**
+ * Slide a dateRange with specific delta
+ * @param dateRange The dateRange to slide.
+ * @param number The number to add
+ * @param unit The unit to add.
+ */
+function slidingWindow(dateRange,number,unit) {
+  dateRange.from=moment(dateRange.from).add(number,unit).format('YYYY-MM-DD HH:mm:ss');
+  dateRange.to=moment(dateRange.to).add(number,unit).format('YYYY-MM-DD HH:mm:ss');
+}
+
+
+function startPipeline(config,onError,onExit) {
+  pipelineRunner('backtest', config, (err, event) => {
+    if (err) {
+      onError(err,event);
+    }
+
+    if (!event) {
+      return; // Crash may be
+    // } else if(event.type === 'trade') {
+    //   log.debug("Receive trade");
+    //   return;
+    // } else if (event.type === 'roundtrip') {
+    //   log.debug("Receive roundtrip");
+    //   return;
+    // } else if (event.type === 'update') {
+    //   log.debug("Receive update");
+    }  else {
+      if (event.report) {
+        onExit(event.report);
+      }
+      else {
+        console.log("unknown event");
+      }
+    }
+  });
+}
+
+function saveReportHeaders() {
+  if (!fs.existsSync(csvpath)) {
+    var headers="";
+    const fields=config.lab.fields;
+    for (var i=0;i<fields.length;++i) {
+      if (fields[i] === 'patchs') {
+        for (var j=0;j<config.lab.values.length;++j) {
+          headers=headers.concat(config.lab.values[j].path).concat(CSV_SEPARATOR)
+        }
+      }
+      else {
+        headers=headers.concat(fields[i]).concat(CSV_SEPARATOR)
+      }
+    }
+    headers=headers.concat('\n');
+
+    fs.writeFileSync(csvpath,headers);
+  }
+}
+
+function calulateResult(report) {
+  const marketDiff=report.endPrice-report.startPrice;
+  const balance=report.balance-report.startBalance;
+  return result=(balance-marketDiff);
+}
+
+function saveReport(report) {
+  var CSV="";
+  const fields=config.lab.fields;
+  for (var i=0;i<fields.length;++i) {
+    const field=fields[i];
+    if (field === 'method') {
+      CSV=CSV.concat(JSON.stringify(config.tradingAdvisor.method)).concat(CSV_SEPARATOR)
+    } else if (field === 'exchange') {
+      CSV=CSV.concat(config.watch.exchange).concat(CSV_SEPARATOR);
+    } else if (field === 'currency') {
+      CSV=CSV.concat(config.watch.currency).concat(CSV_SEPARATOR);
+    } else if (field === 'asset') {
+      CSV=CSV.concat(config.watch.asset).concat(CSV_SEPARATOR);
+    } else if (field === 'candleSize') {
+      CSV=CSV.concat(config.tradingAdvisor.candleSize).concat(CSV_SEPARATOR);
+    } else if (field === 'historySize') {
+      CSV=CSV.concat(config.tradingAdvisor.historySize).concat(CSV_SEPARATOR);
+    } else if (field === 'patchs') {
+      for (var j=0;j<config.lab.values.length;++j) {
+        CSV=CSV.concat(JSON.stringify(config.lab.values[j].value)).concat(CSV_SEPARATOR)
+      }
+    }
+    else if ((field === 'market') || (field === 'relativeProfit')) {
+      if (!report) CSV=CSV.concat("ERROR").concat(CSV_SEPARATOR);
+      else CSV=CSV.concat((report[field]/100).toFixed(4)).concat(CSV_SEPARATOR) // %
+    }
+    else if (field === 'relativeResult') {
+      if (!report) CSV=CSV.concat("ERROR").concat(CSV_SEPARATOR);
+      else CSV=CSV.concat(calulateResult(report).toFixed(4)).concat(CSV_SEPARATOR)
+    } else {
+      if (!report) CSV=CSV.concat("ERROR").concat(CSV_SEPARATOR);
+      else CSV=CSV.concat(JSON.stringify(report[field])).concat(CSV_SEPARATOR)
+    }
+  }
+  CSV=CSV.concat('\n');
+  saveReportHeaders();
+  fs.appendFileSync(csvpath, CSV);
+}
+
+loopContext.loopVariablesAsync=function(index, func, callback) {
+  var done = false;
+  if (index<patchs.length) {
+    const patch = patchs[index];
+    //log.debug(patch.loop[0].replace(/{}/g,patch.path)); // Set
+    try {
+      (function(cmd){
+        return eval(cmd);
+      }).call(loopContext,patch.exloop[0].replace(/{}/g,patch.path)); // Set
+    } catch (e) {
+      log.error("Error when eval '"+patch.exloop[0].replace(/{}/g,patch.path)+"'",e);
+      return;
+    }
+    log.debug("")
+  }
+  const loop = {
+    next: function() {
+      if (done) {
+        return;
+      }
+      const variable = patchs[index];
+      var result;
+      // Test
+      try {
+        result=function(cmd){
+          return eval(cmd);
+        }.call(loopContext,variable.exloop[1].replace(/{}/g,variable.path)); // Check
+      } catch (e) {
+        log.error("Error when eval '"+variable.exloop[1].replace(/{}/g,variable.path)+"'",e);
+        return;
+      }
+      //log.debug(eval(patch.loop[1].replace(/{}/g,patch.path))+" == " +rc);
+      if (result) {
+        func({
+          next: function() {
+            //log.debug(patch.loop[2].replace(/{}/g,patch.path));
+            try {
+              (function(cmd){
+                return eval(cmd);
+              }).call(loopContext,variable.exloop[2].replace(/{}/g,variable.path));
+            } catch(e) {
+              log.error("Error when eval '"+variable.exloop[2].replace(/{}/g,variable.path)+"'",e);
+              return;
+            }
+            loop.next();
+          }
+        },index);
+      } else {
+        done = true;
+        callback();
+      }
+    },
+
+    break: function() {
+      done = true;
+      callback();
+    }
+  };
+  loop.next();
+  return loop;
+};
+
+// Create an invoke a recursive async loop
+loopContext.loopAllPatchsAsync=function(body,done) {
+
+  const nextsCallBack=[];
+
+  for (var i=0;i<patchs.length-1;++i) {
+    nextsCallBack.push(function(loop,index) {
+      loopContext.loopVariablesAsync(
+        index+1,
+        nextsCallBack[index+1],
+        function() {
+          // End inner loop
+          loop.next()
+        }
+      )
+    });
+  }
+  nextsCallBack.push(function(loop)  { body(loop); });
+
+  if (patchs.length>0 && config.lab.enabled) {
+    this.loopVariablesAsync(0,
+      nextsCallBack[0],
+      function() {
+        // End outer loop
+        done()
+      })
+  }
+  else {
+    const pipeline = require(util.dirs().core + 'pipeline');
+    pipeline({
+      config: config,
+      mode: 'backtest'
+    });
+  }
+};
+
+var numberOfTest=0;
+
+function newSimulation(cb) {
+  log.info();
+  log.info("*********************** New Back Test ("+ ++numberOfTest +") ***********************");
+  savePatchedConfig();
+  printPatchedConfig();
+  if (debug) { // FIXME
+    console.write("var config =");
+    console.dir(config);
+    console.write("\nmodule.exports = config;")
+  }
+  startPipeline(config,
+    function(err,event) {
+      saveReport(null);
+      log.info("Impossible to execute this scenario",err);
+      cb();
+    },
+    function(report) {
+      saveReport(report);
+      const result=calulateResult(report);
+      log.info();
+      log.info("Difference with marker ="+result.toFixed(0)+((result>0) ? " (Good deal !)" :""));
+      cb();
+    });
+}
+
+function savePatchedConfig() {
+  config.lab.values=[];
+  for (var i=0;i<patchs.length;++i) {
+    config.lab.values.push({
+      path:patchs[i].path,
+      value:eval("config."+patchs[i].path)
+    })
+  }
+
+}
+
+function printPatchedConfig() {
+  for (var i=0;i<config.lab.values.length;++i) {
+    log.info(config.lab.values[i].path+" = "+JSON.stringify(config.lab.values[i].value))
+  }
+  log.info();
+}
+
+// -------------- Start the experience
+// Reset file
+function resetFile() {
+  if (fs.existsSync(csvpath)) fs.unlinkSync(csvpath);
+  const dir=path.dirname(csvpath);
+  fs.existsSync(dir) || fs.mkdirSync(dir);
+}
+
+// And start the recursive loop
+function start() {
+  resetFile();
+  const startTime=Date.now();
+  loopContext.loopAllPatchsAsync(function(loop) {
+      if (debug) {
+        savePatchedConfig();
+        printPatchedConfig();
+        console.log("Simule... ");
+        loop.next();
+        return;
+      }
+      newSimulation(function(result) {
+        loop.next(); // For cycle could continue
+      })},
+    function(){
+      log.info('All simulations are done. The results are in '+config.lab.file+
+        "("+(moment.duration(Date.now()-startTime).humanize())+")");
+    }
+  );
+
+}
+
+// helper to store the evenutally detected
+// daterange.
+const setDateRange = function(from, to) {
+  config.backtest.daterange = {
+    from: moment.unix(from).utc().format(),
+    to: moment.unix(to).utc().format(),
+  };
+  util.setConfig(config);
+};
+
+if (config.backtest.daterange === 'scan') {
+  scan((err, ranges) => {
+    if(_.size(ranges) === 0)
+      util.die('No history found for this market', true);
+
+    if(_.size(ranges) === 1) {
+      const r = _.first(ranges);
+      log.info('Gekko was able to find a single daterange in the locally stored history:');
+      log.info('\t', 'from:', moment.unix(r.from).utc().format('YYYY-MM-DD HH:mm:ss'));
+      log.info('\t', 'to:', moment.unix(r.to).utc().format('YYYY-MM-DD HH:mm:ss'));
+
+      setDateRange(r.from, r.to);
+      start();
+      return;
+    }
+
+    log.error(
+      'Gekko detected multiple dateranges in the locally stored history.',
+      'Please set \'config.backtest.from\' and \'config.backtest.to\',',
+      'with the daterange you are interested in testing.'
+    );
+  });
+}
+else
+  start();
+
+

--- a/labs/.gitignore
+++ b/labs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/sample-config.js
+++ b/sample-config.js
@@ -436,6 +436,76 @@ config.importer = {
   }
 }
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//                       CONFIGURING LABS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// To use the labs, indicate all the variables to change for each launch
+// with a 'for' loop design.
+// For each variable, add an object in patchs with
+// - 'path' with the name of the variable (in config)
+// - 'loop' with 3 simple pattern
+//    [0] : to initialise the parameter (with '0', use to execute '{} = 0')
+//    [1] : to check the end of the loop (with '< 3' use to execute '{} < 3'
+//    [2] : to increment the parameter (with '+ 1' use to execute '{} = {} + 1'
+// - or 'exloop' with extended pattern like
+// {
+//    path:"backtest.daterange",
+//    exloop:[
+//       '// init',
+//       'moment(config.{}.to).isBefore("2017-03-07")',
+//       'slideWindow(config.{},1, "day")',
+//       '// const x=require(...)
+//    ],
+// }
+//
+// All the results are saved in 'file' with CSV format.
+// To start, use 'node labgekko --backtest --config ...' in place of 'node gekko --backtest --config ...'
+config.lab={
+  enabled:true,
+  file:"labs/"+config.tradingAdvisor.method+".csv",
+  // Fields to add in CSV. Can be omitted or reorders
+  fields:[
+    "method",
+    // "exchange","currency","asset",
+    // "candleSize","historySize",
+    "patchs",
+    // "startTime","endTime","timespan",
+    // "startPrice","endPrice",
+    "market",
+    "trades",
+    // "startBalance","balance","profit",
+    "relativeProfit",
+    "relativeResult" // With first currency=0 and asset=1, compare the market and the relative profit
+  ],
+  // Lists of modification to apply in config.
+  patchs:[
+    { // 10
+      path: "MACD.short",
+      loop: ["5", "<= 15", "+ 5"], // Normal:10
+    },
+    { // 21
+      path: "MACD.long",
+      loop: ["16", "<= 26", "+ 5"], // Normal:21
+    },
+    { // 9
+      path: "MACD.signal",
+      loop: ["8", "<= 10", "+ 1"], // Normal:9
+    },
+    // Sample of complex loop with sliding window
+    // {
+    //   path:"backtest.daterange",
+    //   exloop:[
+    //     'config.{}={from:"2016-01-01", to: "2016-04-01"}',
+    //     'moment(config.{}.to).isBefore("2017-12-15")',
+    //     'slidingWindow(config.{},1, "month")',
+    //     '// require nothing in global scope',
+    //   ],
+    // },
+  ],
+}
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 // set this to true if you understand that Gekko will
 // invest according to how you configured the indicators.
 // None of the advice in the output is Gekko telling you


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This extension launch many times a back test, with different parameters.
All the results are added in a CSV file. It's easy to try different parameters values for the same data, or
to check a strategy in a sliding windows.
See `config.lab` in `sample-config.js`
To start, check the backtest
`node gekko --config <...> --backtest`
then use
`node labgekko --config <...> --backtest`

```
config.lab={
  enabled:true,
  file:"labs/"+config.tradingAdvisor.method+".csv",
  // Fields to add in CSV. Can be omitted or reorders
  fields:[
    "method", "exchange","currency","asset",
    "candleSize","historySize",
    "patchs",
    "startTime","endTime","timespan",
    "startPrice","endPrice","market","trades",
    "startBalance","balance","profit",
    "relativeProfit", "relativeResult"
  ],
  // Lists of modification to apply in config.
  patchs:[
    { 
      path: "MACD.short",
      loop: ["5", "<= 15", "+ 5"], // Normal:10
    },
    { 
      path: "MACD.long",
      loop: ["16", "<= 26", "+ 5"], // Normal:21
    },
    { 
      path: "MACD.signal",
      loop: ["8", "<= 10", "+ 1"], // Normal:9
    },
    {
      path:"backtest.daterange",
      exloop:[
        'config.{}={from:"2016-01-01", to: "2016-04-01"}',
        'moment(config.{}.to).isBefore("2017-12-15")',
        'slidingWindow(config.{},1, "month")',
        '// require nothing in global scope',
      ],
    },
  ],
}
```


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
