### PR TITLE
Adapt roundtrip report logging

### DIFF
--- a/plugins/performanceAnalyzer/logger.js
+++ b/plugins/performanceAnalyzer/logger.js
@@ -44,16 +44,16 @@ Logger.prototype.logReport = function(trade, report) {
 }
 
 Logger.prototype.logRoundtripHeading = function() {
-  log.info('(ROUNDTRIP)', 'entry date\t\texit date\t\texposed duration P&L\t\t\tprofit');
+  log.info('(ROUNDTRIP)', 'entry date      \texit date       \texposed duration\tP&L \tprofit');
 }
 
 Logger.prototype.logRoundtrip = function(rt) {
   const display = [
     rt.entryAt.format('YYYY-MM-DD HH:mm'),
     rt.exitAt.format('YYYY-MM-DD HH:mm'),
-    moment.duration(rt.duration).humanize(),
-    rt.pnl,
-    rt.profit
+    (moment.duration(rt.duration).humanize() + "           ").slice(0,16),
+    rt.pnl.toFixed(2),
+    rt.profit.toFixed(2)
   ];
 
   log.info('(ROUNDTRIP)', display.join('\t'));

--- a/web/vue/src/components/backtester/result/roundtripTable.vue
+++ b/web/vue/src/components/backtester/result/roundtripTable.vue
@@ -17,8 +17,12 @@
           td {{ diff(rt.duration) }}
           td {{ round(rt.entryBalance) }}
           td {{ round(rt.exitBalance) }}
-          td {{ round(rt.pnl) }}
-          td {{ round(rt.profit) }}
+          template(v-if="Math.sign(rt.pnl)===-1")
+            td.loss {{ Math.sign(rt.pnl)*rt.pnl.toFixed(2) }}
+            td.loss {{ rt.profit.toFixed(2) }}%
+          template(v-else)
+            td.profit {{ rt.pnl.toFixed(2) }}
+            td.profit {{ rt.profit.toFixed(2) }}%
     div(v-if='!roundtrips.length')
       p Not enough data to display
 </template>
@@ -53,6 +57,15 @@ export default {
 .roundtrips table td {
   border: 1px solid #c6cbd1;
   padding: 8px 12px;
+}
+
+.roundtrips table td.loss {
+  color: red;
+  text-align: right;
+}
+.roundtrips table td.profit {
+  color: green;
+  text-align: right;
 }
 
 .roundtrips table tr:nth-child(2n) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
adapts roundtrip report logging to use single tab delimiters.
it should be more readable and its easier to copy & paste to excel this way.


* **What is the current behavior?** (You can also link to an open issue here)

![bildschirmfoto 2017-09-26 um 14 01 39](https://user-images.githubusercontent.com/324694/30859288-5244ef48-a2c3-11e7-869e-91740fbe4390.png)


* **What is the new behavior (if this is a feature change)?**

![bildschirmfoto 2017-09-26 um 13 58 09](https://user-images.githubusercontent.com/324694/30859297-5a6f1c84-a2c3-11e7-8038-8d095138b782.png)


* **Other information**: