### PR TITLE
Fix „INVALID_API_KEY“ error, fix #1054

### DIFF
--- a/core/tools/dataStitcher.js
+++ b/core/tools/dataStitcher.js
@@ -177,10 +177,14 @@ Stitcher.prototype.checkExchangeTrades = function(since, next) {
   var provider = config.watch.exchange.toLowerCase();
   var DataProvider = require(util.dirs().gekko + 'exchanges/' + provider);
 
-  var exchangeChecker = require(util.dirs().core + 'exchangeChecker');
-  var exchangeSettings = exchangeChecker.settings(config.watch)
+  var exchangeConfig = config.watch;
+  
+  // include trader config if trading is enabled
+  if (_.isObject(config.trader) && config.trader.enabled) {
+    exchangeConfig = _.extend(config.watch, config.trader);
+  }
 
-  var watcher = new DataProvider(config.watch);
+  var watcher = new DataProvider(exchangeConfig);
 
   watcher.getTrades(since, function(e, d) {
     if(_.isEmpty(d))


### PR DESCRIPTION
Always init exchange with trader config if trader is enabled

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If the trader is initialized after the trading advisor the api key and secret are not set correctly (at least for bittrex) #1054

* **What is the new behavior (if this is a feature change)?**

Now the exchange is always initialized the same way if the trader is enabled

* **Other information**:
