### PR TITLE
Brute forcer proof of concept (Work in progress or As Inspiration) 

### DIFF
--- a/web/vue/package.json
+++ b/web/vue/package.json
@@ -26,6 +26,7 @@
     "webpack-dev-server": "^2.1.0-beta.0"
   },
   "dependencies": {
-    "jade": "^1.11.0"
+    "jade": "^1.11.0",
+    "shuffle-array": "^1.0.1"
   }
 }

--- a/web/vue/src/components/backtester/backtester.vue
+++ b/web/vue/src/components/backtester/backtester.vue
@@ -10,11 +10,13 @@
           p Running backtest..
           spinner
     result(v-if='backtestResult && backtestState === "fetched"', :result='backtestResult')
+    bruteForceResults(v-if='bruteForceResults && bruteForceResultState === "newResult"', :bruteForceResults='bruteForceResults')
 </template>
 
 <script>
 import configBuilder from './backtestConfigBuilder.vue'
 import result from './result/result.vue'
+import bruteForceResults from './result/bruteForceResults.vue'
 import { post } from '../../tools/ajax'
 import spinner from '../global/blockSpinner.vue'
 
@@ -24,12 +26,12 @@ export default {
       backtestable: false,
       backtestState: 'idle',
       backtestResult: false,
+      bruteForceResults: [],
       config: false,
     }
   },
   methods: {
     check: function(config) {
-      // console.log('CHECK', config);
       this.config = config;
 
       if(!config.valid)
@@ -38,28 +40,70 @@ export default {
       this.backtestable = true;
     },
     run: function() {
-      this.backtestState = 'fetching';
+      debugger
+      const self = this;
+      // Are we brute forcing the strategy params?
+      if (window.bruteForcer && window.bruteForcer.isConfigured()) {
+        // window.bruteForceResult = { };
+        self.bruteForceResults = [];
 
-      const req = {
-        gekkoConfig: this.config,
-        data: {
-          candleProps: ['close', 'start'],
-          indicatorResults: true,
-          report: true,
-          roundtrips: true,
-          trades: true
+        let i = 0;
+        function myLoop (i) {
+          if (i < window.bruteForcer.config.bruteforceParamsPermutations.length) {
+            setTimeout(function () {
+              this.backtestState = 'fetching';
+              self.bruteForceResultState = 'fetching';
+              console.log(' + Testing strategy with params: ', window.bruteForcer.config.bruteforceParamsPermutations[i]['params']);
+              // Prepare config using a permuted params combination
+              self.config[self.config.tradingAdvisor.method] = window.bruteForcer.config.bruteforceParamsPermutations[i]['params'];
+              const req = {
+                gekkoConfig: self.config,
+                data: {
+                  candleProps: ['close', 'start'],
+                  indicatorResults: true,
+                  report: true,
+                  roundtrips: true,
+                  trades: true
+                }
+              }
+              post('backtest', req, (error, response) => {
+                self.bruteForceResultState = 'newResult';
+                this.backtestState = 'fetched';
+                // self.backtestResult = response;
+                // window.bruteForceResult[response['report']['relativeProfit']] = response;
+                self.bruteForceResults.push(response);
+              });
+              i++;
+              myLoop(i);
+            }, 5000);
+          }
         }
-      }
+        myLoop(i);
+      } else {
+      // Are we just testing a single set of params?
+        this.backtestState = 'fetching';
+        const req = {
+          gekkoConfig: this.config,
+          data: {
+            candleProps: ['close', 'start'],
+            indicatorResults: true,
+            report: true,
+            roundtrips: true,
+            trades: true
+          }
+        }
 
-      post('backtest', req, (error, response) => {
-        this.backtestState = 'fetched';
-        this.backtestResult = response;
-      });
+        post('backtest', req, (error, response) => {
+          this.backtestState = 'fetched';
+          this.backtestResult = response;
+        });
+      }
     }
   },
   components: {
     configBuilder,
     result,
+    bruteForceResults,
     spinner
   }
 }

--- a/web/vue/src/components/backtester/result/bruteForceResults.vue
+++ b/web/vue/src/components/backtester/result/bruteForceResults.vue
@@ -2,18 +2,14 @@
   div
     .hr.contain
     div.contain
-      h3 Backtest result
-    result-summary(:report='result.report')
-    .hr.contain
-    chart(:data='result', height='500')
-    .hr.contain
-    roundtripTable(:roundtrips='result.roundtrips')
-    div(v-for='result in bruteForceResult')
+      h3 Bruteforce result
+    div(v-for='result in bruteForceResults')
       result-summary(:report='result.report')
-      .hr.contain
-      chart(:data='result', height='500')
-      .hr.contain
-      roundtripTable(:roundtrips='result.roundtrips')
+      .hr
+      // .hr.contain
+      // chart(:data='result', height='500')
+      // .hr.contain
+      // roundtripTable(:roundtrips='result.roundtrips')
 </template>
 
 <script>
@@ -22,7 +18,7 @@ import chart from './chartWrapper.vue'
 import roundtripTable from './roundtripTable.vue'
 
 export default {
-  props: ['result'],
+  props: ['bruteForceResults'],
   data: () => {
     return {}
   },

--- a/web/vue/src/components/backtester/result/bruteForceResults.vue
+++ b/web/vue/src/components/backtester/result/bruteForceResults.vue
@@ -2,14 +2,15 @@
   div
     .hr.contain
     div.contain
-      h3 Bruteforce result
-    div(v-for='result in bruteForceResults')
-      result-summary(:report='result.report')
-      .hr
-      // .hr.contain
-      // chart(:data='result', height='500')
-      // .hr.contain
-      // roundtripTable(:roundtrips='result.roundtrips')
+      h3.top-10 Top 10 by profit
+      div.count Tested {{ bruteForcedResultsCount }} of {{bruteForceCombinationsCount}} combinations
+    div(v-for='topResult in topResultsByProfit')
+      div.contain
+        div.tested-params
+          span(v-for="(paramValue, paramName) in topResult.params")
+            span.param-name {{ paramName }}&nbsp;
+            span.param-value {{ paramValue }}&nbsp;
+      result-summary(:report='topResult.report')
 </template>
 
 <script>
@@ -18,7 +19,7 @@ import chart from './chartWrapper.vue'
 import roundtripTable from './roundtripTable.vue'
 
 export default {
-  props: ['bruteForceResults'],
+  props: ['bruteForcedResultsCount', 'bruteForceCombinationsCount', 'topResultsByProfit'],
   data: () => {
     return {}
   },
@@ -32,4 +33,19 @@ export default {
 </script>
 
 <style>
+  .top-10 {
+    font-weight: 600;
+  }
+  .top-10, .count {
+    text-align: center;
+  }
+  .tested-params {
+    text-align: center;
+    border: 1px dashed rgba(144,144,144,.99);
+    margin: 15px 0;
+    padding: 5px;
+  }
+  .param-name {
+    font-weight: 600;
+  }
 </style>

--- a/web/vue/src/components/global/configbuilder/stratpicker.vue
+++ b/web/vue/src/components/global/configbuilder/stratpicker.vue
@@ -28,7 +28,12 @@
         h3 Parameters
         p {{ strategy }} Parameters:
         textarea.params(v-model='rawStratParams')
-        p.bg--red.p1(v-if='rawStratParamsError') {{ rawStratParamsError.message }}
+        .bf
+          .checkbox
+            label(for='bruteforce') Bruteforce
+            input(type='checkbox', name='bruteforce', v-model='bruteForce')
+            em.label-like test all combinations
+    p.bg--red.p1(v-if='rawStratParamsError') {{ rawStratParamsError.message }}
 </template>
 
 <script>
@@ -51,7 +56,9 @@ export default {
       rawStratParamsError: false,
 
       emptyStrat: false,
-      stratParams: {}
+      stratParams: {},
+
+      bruteForce: false
     };
   },
   created: function () {
@@ -73,6 +80,11 @@ export default {
       this.rawStratParams = strat.params;
       this.emptyStrat = strat.empty;
 
+      this.emitConfig();
+    },
+    bruteForce: function(value) {
+      // Configure the brute forcer
+      if (value) { this.configBruteForce(); }
       this.emitConfig();
     },
     candleSize: function() { this.emitConfig() },
@@ -116,6 +128,12 @@ export default {
       this.parseParams();
       this.$emit('stratConfig', this.config);
     },
+    configBruteForce: function() {
+      console.log('Configuring brute force from strategy params :', toml.parse(this.rawStratParams));
+      window.bruteForcer = new MarketBacktestBruteforcer();
+      window.bruteForcer.configure(toml.parse(this.rawStratParams));
+      console.log('bruteforcer config: ', window.bruteForcer.config);
+    },
     parseParams: function() {
       try {
         this.stratParams = toml.parse(this.rawStratParams);
@@ -141,5 +159,24 @@ export default {
 
 .align {
   padding-left: 1em;
+}
+
+.bf .checkbox label {
+  margin-top: 10px;
+  margin-left: 10px;
+}
+
+.bf .label-like {
+  display: inline;
+}
+
+.bf .checkbox input[type="checkbox"] {
+  display: inline;
+  margin-right: 5px;
+  margin-left: 10px;
+}
+
+.bf .checkbox input[type="checkbox"] {
+  width: auto;
 }
 </style>

--- a/web/vue/src/components/global/ws.js
+++ b/web/vue/src/components/global/ws.js
@@ -3,6 +3,8 @@ import Vue from 'vue'
 
 import { wsPath } from '../../tools/api'
 import initializeState from '../../store/init'
+import { MarketBacktestBruteforcer } from '../../tools/bruteforcer'
+window.MarketBacktestBruteforcer = MarketBacktestBruteforcer
 
 var socket = null;
 

--- a/web/vue/src/tools/bruteforcer.js
+++ b/web/vue/src/tools/bruteforcer.js
@@ -21,11 +21,11 @@ let shuffle = require('shuffle-array')
     */
    prepareParamNames(params) {
      const paramNames = Object.keys(params);
-     let subParams;
-     for (let i = 0; i < paramNames.length; i++) {
+     let subParams, i, i2;
+     for (i = 0; i < paramNames.length; i++) {
        if (typeof(params[paramNames[i]]) == 'object') {
          subParams = Object.keys(params[paramNames[i]]);
-         for (let i2 = 0; i2 < subParams.length; i2++) {
+         for (i2 = 0; i2 < subParams.length; i2++) {
            paramNames.push(paramNames[i]+'.'+subParams[i2]);
            if (i2+1==subParams.length) {
              paramNames.splice(i, 1);
@@ -40,8 +40,8 @@ let shuffle = require('shuffle-array')
     * Transforms '.' notation to JSON object
     */
    transformParamNames(params) {
-     let finalParams = {}, paramsKeys = Object.keys(params), rootKey, childKey, dotI;
-     for (var i = 0; i < paramsKeys.length; i++) {
+     let finalParams = {}, paramsKeys = Object.keys(params), rootKey, childKey, dotI, i;
+     for (i = 0; i < paramsKeys.length; i++) {
        dotI = paramsKeys[i].indexOf('.');
        if (dotI != -1) {
          rootKey = paramsKeys[i].slice(0,dotI);
@@ -71,7 +71,7 @@ let shuffle = require('shuffle-array')
        paramValue = dotPos != -1 ? eval('params["'+paramNames[i].slice(0, dotPos)+'"]["'+paramNames[i].slice(dotPos+1, paramNames[i].length)+'"]') : params[paramNames[i]];
        paramsConfig.push({
          name:  paramNames[i],
-         from:  paramValue,      // TODO: this has to be dynamic and valid
+         from:  paramValue - 2,      // TODO: this has to be dynamic and valid
          to:    paramValue + 2,     // TODO: this has to be dynamic and valid
          step:  1                    // TODO: this has to be dynamic and valid
        });
@@ -115,19 +115,19 @@ let shuffle = require('shuffle-array')
     * Prepares the parameters values from a configuration of parameters
     */
    prepareParamsValues(paramsConfig) {
-     let paramsValues = {};
+     let paramsValues = {}, i, i2;
 
-     for (let i = 0; i < paramsConfig.length; i++) {
+     for (i = 0; i < paramsConfig.length; i++) {
        const pmConf = paramsConfig[i];
        paramsValues[pmConf['name']] = [];
        // Prepare "from" -- "to" combinations
        if (typeof(pmConf['from']) != 'undefined' && typeof(pmConf['to']) != 'undefined') {
-          for (let i2 = pmConf['from']; i2 <= pmConf['to']; i2=i2+pmConf['step']) {
+          for (i2 = pmConf['from']; i2 <= pmConf['to']; i2=i2+pmConf['step']) {
             paramsValues[pmConf['name']].push(i2);
           }
        // Prepare "values" combinations
        } else if (pmConf['values']) {
-          for (let i2 = 0; i2 < pmConf['values'].length; i2++) {
+          for (i2 = 0; i2 < pmConf['values'].length; i2++) {
             paramsValues[pmConf['name']].push(pmConf['values'][i2]);
           }
        }
@@ -159,18 +159,18 @@ let shuffle = require('shuffle-array')
      }
      const inputParamNames = Object.keys(inputParamsValues);
 
-     for (let i = 0; i < inputParamNames.length; i++) {
+     let i, i2, valuesToConsider, combinationMade, newParamsCombinations, newInputParamsValues;
+     for (i = 0; i < inputParamNames.length; i++) {
        if (typeof(paramsCombinations[inputParamNames[i]]) == 'undefined') {
          const inputParamValues = inputParamsValues[inputParamNames[i]];
-         let valuesToConsider;
-         for (var i2 = 0; i2 < inputParamValues.length; i2++) {
+         for (i2 = 0; i2 < inputParamValues.length; i2++) {
            (function(paramCombinationNames, inputParamsValues, paramsCombinations, permuted, valuesToConsider) {
-             let combinationMade = false;
+             combinationMade = false;
              // Only store a permutation when we are considering values for all inputs
              valuesToConsider = inputParamsValues[inputParamNames[i]].slice(i2+1, inputParamsValues[inputParamNames[i]].length);
              inputParamsValues[inputParamNames[i]] = valuesToConsider;
              // Prepare a new set of parameter combinations
-             let newParamsCombinations = Object.assign({}, paramsCombinations);
+             newParamsCombinations = Object.assign({}, paramsCombinations);
              newParamsCombinations[inputParamNames[i]] = inputParamValues[i2];
              // Is the parameter combinations complete? Then push it to the permuted list
              if (Object.keys(newParamsCombinations).length == paramCombinationNames.length) {
@@ -180,7 +180,7 @@ let shuffle = require('shuffle-array')
                permuted.push(newParamsCombinations);
                newParamsCombinations = {};
              }
-             let newInputParamsValues = Object.assign({}, inputParamsValues);
+             newInputParamsValues = Object.assign({}, inputParamsValues);
              // Did we finish all possible values for a parameter?
              if (newInputParamsValues[inputParamNames[i]].length == 0) {
                // Now we remove the parameter considered from the recursive combinations

--- a/web/vue/src/tools/bruteforcer.js
+++ b/web/vue/src/tools/bruteforcer.js
@@ -1,0 +1,165 @@
+import {post} from './ajax'
+
+/**
+ * Market brute forcer (proof of concept)
+ * @author David Valin <hola@davidvalin.com>
+ */
+ export class MarketBacktestBruteforcer {
+   /**
+    * Initializes the market brute forcer
+    */
+   constructor() {
+     this.config = {
+       paramsConfig: [],
+       bruteforceParamsPermutations: []
+     };
+   }
+
+   /**
+    * Prepares the parameter value ranges to test from a strategy
+    * @param params : the params used to prepare the ranges to test
+    * @return paramsConfig : the configuration of params to brute force
+    */
+   prepareRangesFromParams(params) {
+    //  console.log('Preparing the value ranges from those params: ', params);
+     const paramNames = Object.keys(params); // TODO: consider nested params, only first level params are considered
+     let paramsConfig = [];
+
+     for (var i = 0; i < paramNames.length; i++) {
+       if (typeof(params[paramNames[i]]) != 'object') {
+         paramsConfig.push({
+           name:  paramNames[i],
+           from:  params[paramNames[i]],          // TODO: this has to be dynamic and valid
+           to:    (params[paramNames[i]] + 100),  // TODO: this has to be dynamic and valid
+           step:  1                               // TODO: this has to be dynamic and valid
+         });
+       }
+     }
+     debugger
+     return paramsConfig;
+   }
+
+   /**
+    * Configures the market bruteforcer
+    * @param strategyParams : The strategy default parameters to use to configure the brute forcer
+    */
+   configure(strategyParams) {
+     // Configure the param value ranges
+     this.config.paramsConfig = this.prepareRangesFromParams(strategyParams);
+     this.config.bruteforceParamsPermutations = [];
+
+     // Permute the parameters
+     const permuteParams = this.permuteParams();
+     // For each parameter combination
+     for (let i = 0; i < permuteParams.length; i++) {
+       // Push test combinations
+       this.config.bruteforceParamsPermutations.push({
+        //  currency:  this.config.pairList[i].slice(0,3),
+        //  asset:     this.config.pairList[i].slice(3,6),
+         params:    permuteParams[i]
+       });
+     }
+   }
+
+   /**
+    * Retrieves the params names
+    */
+   getParamsName() {
+     return this.paramsConfig.map(function(paramsSet) {
+       return paramsSet['name'];
+     });
+   }
+
+   /**
+    * Prepares the parameters values from a configuration of parameters
+    */
+   prepareParamsValues(paramsConfig) {
+     let paramsValues = {};
+
+     for (let i = 0; i < paramsConfig.length; i++) {
+       const pmConf = paramsConfig[i];
+       paramsValues[pmConf['name']] = [];
+       // Prepare "from" -- "to" combinations
+       if (typeof(pmConf['from']) != 'undefined' && typeof(pmConf['to']) != 'undefined') {
+          for (let i2 = pmConf['from']; i2 <= pmConf['to']; i2=i2+pmConf['step']) {
+            paramsValues[pmConf['name']].push(i2);
+          }
+       // Prepare "values" combinations
+       } else if (pmConf['values']) {
+          for (let i2 = 0; i2 < pmConf['values'].length; i2++) {
+            paramsValues[pmConf['name']].push(pmConf['values'][i2]);
+          }
+       }
+     }
+     return paramsValues;
+   }
+
+   /**
+    * Using the bruteforce params configuration, permutes the params
+    */
+   permuteParams(paramCombinationNames, inputParamsValues, paramsCombinations, permuted) {
+     const self = this;
+     // Grab the paramsConfig first
+     if (!inputParamsValues) {
+       inputParamsValues = this.prepareParamsValues(this.config.paramsConfig);
+     }
+     // Store the original list of parameter names to permute
+     if (!paramCombinationNames) {
+       paramCombinationNames = Object.keys(inputParamsValues);
+     }
+     if (!paramsCombinations) {
+       paramsCombinations = {};
+     }
+
+     // Initialize an empty set of permutations
+     if (!permuted) {
+       console.log(' + Permuting params values from input params values: ', inputParamsValues);
+       permuted = [];
+     }
+     const inputParamNames = Object.keys(inputParamsValues);
+
+     for (let i = 0; i < inputParamNames.length; i++) {
+       if (typeof(paramsCombinations[inputParamNames[i]]) == 'undefined') {
+         const inputParamValues = inputParamsValues[inputParamNames[i]];
+         let valuesToConsider;
+         for (var i2 = 0; i2 < inputParamValues.length; i2++) {
+           (function(paramCombinationNames, inputParamsValues, paramsCombinations, permuted, valuesToConsider) {
+             let combinationMade = false;
+             // Only store a permutation when we are considering values for all inputs
+             valuesToConsider = inputParamsValues[inputParamNames[i]].slice(i2+1, inputParamsValues[inputParamNames[i]].length);
+             inputParamsValues[inputParamNames[i]] = valuesToConsider;
+             // Prepare a new set of parameter combinations
+             let newParamsCombinations = Object.assign({}, paramsCombinations);
+             newParamsCombinations[inputParamNames[i]] = inputParamValues[i2];
+             // Is the parameter combinations complete? Then push it to the permuted list
+             if (Object.keys(newParamsCombinations).length == paramCombinationNames.length) {
+               combinationMade = true;
+             }
+             if (combinationMade) {
+               permuted.push(newParamsCombinations);
+               newParamsCombinations = {};
+             }
+             let newInputParamsValues = Object.assign({}, inputParamsValues);
+             // Did we finish all possible values for a parameter?
+             if (newInputParamsValues[inputParamNames[i]].length == 0) {
+               // Now we remove the parameter considered from the recursive combinations
+               delete newInputParamsValues[inputParamNames[i]];
+             }
+            // Do we have any param value to consider in this iteration?
+            if (!combinationMade && Object.keys(newInputParamsValues).length > 0) {
+              self.permuteParams(paramCombinationNames, newInputParamsValues, newParamsCombinations, permuted);
+            }
+          })(paramCombinationNames, inputParamsValues, paramsCombinations, permuted, valuesToConsider);
+         }
+       }
+     }
+     return permuted;
+   }
+
+   /**
+    * Checks wether the brute forcer is configured or not
+    */
+   isConfigured() {
+    return (this.config && this.config.bruteforceParamsPermutations && this.config.bruteforceParamsPermutations.length > 0 ? true : false);
+   }
+ }

--- a/web/vue/src/tools/bruteforcer.js
+++ b/web/vue/src/tools/bruteforcer.js
@@ -1,4 +1,5 @@
 import {post} from './ajax'
+let shuffle = require('shuffle-array')
 
 /**
  * Market brute forcer (proof of concept)
@@ -70,8 +71,8 @@ import {post} from './ajax'
        paramValue = dotPos != -1 ? eval('params["'+paramNames[i].slice(0, dotPos)+'"]["'+paramNames[i].slice(dotPos+1, paramNames[i].length)+'"]') : params[paramNames[i]];
        paramsConfig.push({
          name:  paramNames[i],
-         from:  paramValue - 5,      // TODO: this has to be dynamic and valid
-         to:    paramValue + 5 ,     // TODO: this has to be dynamic and valid
+         from:  paramValue,      // TODO: this has to be dynamic and valid
+         to:    paramValue + 2,     // TODO: this has to be dynamic and valid
          step:  1                    // TODO: this has to be dynamic and valid
        });
      }
@@ -88,7 +89,8 @@ import {post} from './ajax'
      this.config.bruteforceParamsPermutations = [];
 
      // Permute the parameters
-     const permuteParams = this.permuteParams();
+     let permuteParams = this.permuteParams();
+     permuteParams = shuffle(permuteParams);
      // For each parameter combination
      for (let i = 0; i < permuteParams.length; i++) {
        // Push test combinations


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Unfinished feature to test ranges of strategy params permutations. This will allow to find out the most profitable strategy params for a dataset.

* **What is the current behavior?** (You can also link to an open issue here)
Renders the top 10 strategy params tested until now based on their profits (ranges of values to test are hardcoded still)

* **What is the new behavior (if this is a feature change)?**
It should render a list of results sorted by most profitable params combination in the backtest view from a test params configuration form

* **Other information**:
I started playing around this this but unfortunately I don't have time to complete the feature. I hope someone can use it as inspiration or pick it up and finish it. 

![captura de pantalla 2017-10-30 a las 2 40 02](https://user-images.githubusercontent.com/841133/32151266-ce86593a-bd1b-11e7-8417-9ce0683d6dbd.png)
