### PR TITLE
Feature/issue 1154 prettier roundtrips

### DIFF
--- a/web/vue/src/components/backtester/result/result.vue
+++ b/web/vue/src/components/backtester/result/result.vue
@@ -7,7 +7,7 @@
     .hr.contain
     chart(:data='result', height='500')
     .hr.contain
-    roundtripTable(:roundtrips='result.roundtrips')
+    roundtripTable(:roundtrips='result.roundtrips', :report='result.report')
 </template>
 
 <script>

--- a/web/vue/src/components/backtester/result/roundtripTable.vue
+++ b/web/vue/src/components/backtester/result/roundtripTable.vue
@@ -1,9 +1,28 @@
 <template lang='jade'>
   .contain.roundtrips
     h2 Roundtrips
+    .contain.sort-controls
+      .grd-row
+        .grd-row-col-3-6.mx1
+          label(for='sortBy').wrapper Sort By:
+          .custom-select.button
+            select(v-model='sortBy')
+              option(value='entryAt') Entry at
+              option(value='exitAt') Exit at
+              option(value='entryBalance') Entry balance
+              option(value='exitBalance') Exit balance
+              option(value='profit') Profit
+              label(for='currency') Currency:
+        .grd-row-col-3-6.mx1
+          label(for='sortOrder').wrapper Order:  
+          .custom-select.button
+            select(v-model='sortOrder')
+              option(value='descending') Descending
+              option(value='ascending') Ascending
     table(v-if='roundtrips.length')
       thead
         tr
+          th Row
           th Entry at
           th Exit at
           th Exposure
@@ -11,33 +30,57 @@
           th Exit balance
           th P&amp;L
           th Profit
-        tr(v-for='rt in roundtrips')
+        tr(v-for="(rt, index) in sort(roundtrips, sortBy, sortOrder)")
+          td {{ index + 1 }}
           td {{ fmt(rt.entryAt) }}
           td {{ fmt(rt.exitAt) }}
           td {{ diff(rt.duration) }}
-          td {{ round(rt.entryBalance) }}
-          td {{ round(rt.exitBalance) }}
+          td {{ round(rt.entryBalance) }} 
+            span.font-secondary {{ report.currency }}
+          td {{ round(rt.exitBalance) }} 
+            span.font-secondary {{ report.currency }}
           template(v-if="Math.sign(rt.pnl)===-1")
-            td.loss {{ Math.sign(rt.pnl)*rt.pnl.toFixed(2) }}
-            td.loss {{ rt.profit.toFixed(2) }}%
+            td.loss {{ Math.sign(rt.pnl)*rt.pnl.toFixed(2) }} 
+              span.font-secondary {{ report.currency }}
+            td.loss {{ rt.profit.toFixed(2) }} 
+              span.font-secondary %
           template(v-else)
-            td.profit {{ rt.pnl.toFixed(2) }}
-            td.profit {{ rt.profit.toFixed(2) }}%
+            td.profit {{ rt.pnl.toFixed(2) }} 
+              span.font-secondary {{ report.currency }}
+            td.profit {{ rt.profit.toFixed(2) }} 
+              span.font-secondary %
     div(v-if='!roundtrips.length')
       p Not enough data to display
 </template>
 
 <script>
 export default {
-  props: ['roundtrips'],
+  props: ['roundtrips', 'report'],
   data: () => {
-    return {}
+    return {
+      sortBy: 'entryAt',
+      sortOrder: 'ascending',
+    }
   },
   methods: {
     diff: n => moment.duration(n).humanize(),
     humanizeDuration: (n) => window.humanizeDuration(n),
     fmt: mom => moment.utc(mom).format('YYYY-MM-DD HH:mm'),
-    round: n => (+n).toFixed(3),
+    round: n => (+n).toFixed(2),
+    sort: (data, key, order) => {
+      if (!key) {
+        return data;
+      }
+      return data.slice().sort(function (a, b) {
+        let itemA = a[key];
+        let itemB = b[key];
+        if (key === 'entryAt' || key === 'exitAt') {
+          itemA = moment(itemA).utc();
+          itemB = moment(itemB).utc();
+        }
+        return order === 'ascending' ? (itemA - itemB) : (itemB - itemA);
+      });
+    },
   },
 }
 </script>
@@ -49,6 +92,10 @@ export default {
   margin-bottom: 50px;
 }
 
+.sort-controls {
+  margin-bottom: 18px;
+}
+
 .roundtrips table {
   width: 100%;
 }
@@ -56,16 +103,22 @@ export default {
 .roundtrips table th,
 .roundtrips table td {
   border: 1px solid #c6cbd1;
-  padding: 8px 12px;
+  padding: 8px 10px;
 }
 
 .roundtrips table td.loss {
   color: red;
-  text-align: right;
 }
 .roundtrips table td.profit {
-  color: green;
+  color: #2ecc71;
+}
+
+.roundtrips table td:last-child {
   text-align: right;
+}
+
+.roundtrips table td .font-secondary {
+  color: #999;
 }
 
 .roundtrips table tr:nth-child(2n) {

--- a/web/vue/src/components/global/paperTradeSummary.vue
+++ b/web/vue/src/components/global/paperTradeSummary.vue
@@ -54,7 +54,7 @@ export default {
 }
 
 .price.profit {
-  color: #7FFF00;
+  color: #2ecc71;
 }
 
 .price.loss {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small UI/Front end feature with added functionality for users and some small UI bug fixes/issue requests


* **What is the current behavior?** (You can also link to an open issue here)
Currently there is no ability to sort the roundtrip data at all in the web UI, nor were there any currency symbols in the entry/exit balance columns, plus some other small changes like the green text colour changing for both the Round Trip view and the Paper Trade summary view.


* **What is the new behavior (if this is a feature change)?**
Adds front end sort functionality for the Round Trips view, can sort data by a specific column in ascending or descending order, including number and time data. Also adds currency symbols and some other small fixes from #1154 

