### PR TITLE
add timeout option for api in uiconfig

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -77,7 +77,7 @@ app
   .use(router.routes())
   .use(router.allowedMethods());
 
-server.timeout = config.api.timeout;
+server.timeout = config.api.timeout||120000;
 server.on('request', app.callback());
 server.listen(config.api.port, config.api.host, '::', () => {
   const host = `${config.ui.host}:${config.ui.port}${config.ui.path}`;

--- a/web/server.js
+++ b/web/server.js
@@ -77,6 +77,7 @@ app
   .use(router.routes())
   .use(router.allowedMethods());
 
+server.timeout = config.api.timeout;
 server.on('request', app.callback());
 server.listen(config.api.port, config.api.host, '::', () => {
   const host = `${config.ui.host}:${config.ui.port}${config.ui.path}`;

--- a/web/vue/UIconfig.js
+++ b/web/vue/UIconfig.js
@@ -7,7 +7,8 @@ const CONFIG = {
   headless: false,
   api: {
     host: '127.0.0.1',
-    port: 3000,
+    port: 3001,
+    timeout: 120000 // 2 minutes
   },
   ui: {
     ssl: false,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

nodejs server has default timeout of 2 minutes. This PR adds a timeout configuration option to uiconfig for api ability to run backtests with longer execution time

* **What is the current behavior?** (You can also link to an open issue here)

api backtest is capped at 2 minutes

* **What is the new behavior (if this is a feature change)?**

users will be able to extend the timeout beyond the default time of 2 minutes to allow for longer backtest execution (eg:  multiple async runs using 1 year data with 1 minute candles... or just a slower system such as a raspberry pi using large data)

* **Other information**:
