### PR TITLE
fix sqlite pragma to use config setting

### DIFF
--- a/plugins/sqlite/handle.js
+++ b/plugins/sqlite/handle.js
@@ -50,7 +50,7 @@ if(mode === 'realtime' || mode === 'importer') {
 }
 
 var db = new sqlite3.Database(fullPath);
-db.run("PRAGMA journal_mode = WAL");
+db.run('PRAGMA journal_mode = ' + config.sqlite.journalMode||'WAL');
 db.configure('busyTimeout', 1500);
 
 module.exports = db;

--- a/web/routes/baseConfig.js
+++ b/web/routes/baseConfig.js
@@ -41,10 +41,9 @@ config.adapter = UIconfig.adapter;
 
 config.sqlite = {
   path: 'plugins/sqlite',
-
-  dataDirectory: 'history',
   version: 0.1,
-
+  dataDirectory: 'history',
+  journalMode: 'WAL', // setting this to 'DEL' may prevent db locking on windows
   dependencies: [{
     module: 'sqlite3',
     version: '3.1.4'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

    add config setting back to pragma for sqlite plugin

* **What is the current behavior?** (You can also link to an open issue here)

    sqlite plugin somehow got set back to just use hard coded WAL pragma

* **What is the new behavior (if this is a feature change)?**

    sqlite will once again use setting from plugin config, or default to WAL if no config setting specified

* **Other information**:
