### PR TITLE
docs(supported_exchanges): use check and x symbols

### DIFF
--- a/docs/introduction/supported_exchanges.md
+++ b/docs/introduction/supported_exchanges.md
@@ -4,25 +4,48 @@ Gekko is able to directly communicate with the APIs of a number of exchanges. Ho
 
 - Monitoring: Gekko is able to retrieve live market data from the exchange. Gekko can store and run trading simulations over this data.
 - Live Trading: Gekko is able to automatically execute orders (based on the signals of your strategy). This turns Gekko into a trading bot.
-- Importing: Gekko is able to retrieve historical market data. This way you can easily get a month of market data over which you can [backtest](../features/backtesting.md) your strategy.
+- Importing: Gekko is able to retrieve historical market data. This way you can easily get a month of market data over which you can [backtest][1] your strategy.
 
-| Exchange        | Monitoring | Live Trading | Importing | Notes |
-| --------------- |:----------:|:-------:|:---------:|-------|
-| [Poloniex](https://poloniex.com/)      | V | V | V | |
-| [GDAX](https://gdax.com/)      | V | V | V | |
-| [BTCC](https://btcc.com/)      | V | V | V | (=BTCChina) |
-| [Bitstamp](https://bitstamp.com/)      | V | V | V | |
-| [Kraken](https://kraken.com/)      | V | V | V | |
-| [Bitfinex](https://bitfinex.com/)      | V | V | V | |
-| [Bittrex](https://bittrex.com/)      | V | V | X | |
-| [wex.nz](https://wex.nz/)      | V | V | X | |
-| [Gemini](https://gemini.com/)      | V | V | X | |
-| [Okcoin.cn](https://www.okcoin.cn/)      | V | V | X | (China, see [#352](https://github.com/askmike/gekko/pull/352)) |
-| [Cex.io](https://cex.io/)      | V | X | X | |
-| [BTC Markets](https://btcmarkets.net)      | V | V | X | |
-| [bitX](https://www.bitx.co/)      | V | X | X | |
-| [lakeBTC](https://lakebtc.com/)      | V | X | X | |
-| [meXBT](https://mexbt.com/)      | V | X | X | see [here](https://github.com/askmike/gekko/issues/288#issuecomment-223810974). |
-| [zaif](https://zaif.jp/trade_btc_jpy)      | V | X | X | |
-| [lakeBTC](https://lakebtc.com/)      | V | X | X | |
-| [bx.in.th](https://bx.in.th/)      | V | X | X | |
+| Exchange             | Monitoring | Live Trading | Importing | Notes                    |
+| -------------------- |:----------:|:------------:|:---------:| ------------------------ |
+| [Poloniex][2]        | ✓          | ✓            | ✓         |                          |
+| [GDAX][3]            | ✓          | ✓            | ✓         |                          |
+| [BTCC][4]            | ✓          | ✓            | ✓         | (=BTCChina)              |
+| [Bitstamp][5]        | ✓          | ✓            | ✓         |                          |
+| [Kraken][6]          | ✓          | ✓            | ✓         |                          |
+| [Bitfinex][7]        | ✓          | ✓            | ✓         |                          |
+| [Bittrex][8]         | ✓          | ✓            | ✕         |                          |
+| [wex.nz][9]          | ✓          | ✓            | ✕         |                          |
+| [wex.nz][9]          | ✓          | ✓            | ✕         |                          |
+| [Gemini][10]         | ✓          | ✓            | ✕         |                          |
+| [Okcoin.cn][11]      | ✓          | ✓            | ✕         | China, see [#352][20]    |
+| [Cex.io][12]         | ✓          | ✕            | ✕         |                          |
+| [BTC Markets][13]    | ✓          | ✓            | ✕         |                          |
+| [bitX][14]           | ✓          | ✕            | ✕         |                          |
+| [lakeBTC][15]        | ✓          | ✕            | ✕         |                          |
+| [meXBT][16]          | ✓          | ✕            | ✕         | see [here][21]           |
+| [zaif][17]           | ✓          | ✕            | ✕         |                          |
+| [lakeBTC][18]        | ✓          | ✕            | ✕         |                          |
+| [bx.in.th][19]       | ✓          | ✕            | ✕         |                          |
+
+[1]: ../features/backtesting.md
+[2]: https://poloniex.com
+[3]: https://gdax.com
+[4]: https://btcc.com
+[5]: https://bitstamp.com
+[6]: https://kraken.com
+[7]: https://bitfinex.com
+[8]: https://bittrex.com
+[9]: https://wex.nz
+[10]: https://gemini.com
+[11]: https://www.okcoin.cn
+[12]: https://cex.io
+[13]: https://btcmarkets.net
+[14]: https://www.bitx.co
+[15]: https://lakebtc.com
+[16]: https://mexbt.com
+[17]: https://zaif.jp/trade_btc_jpy
+[18]: https://lakebtc.com
+[19]: https://bx.in.th
+[20]: https://github.com/askmike/gekko/pull/352
+[21]: https://github.com/askmike/gekko/issues/288#issuecomment-223810974


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Docs.

**What is the current behavior?**
_I think_ the `V` in the table is attempting to symbolize a check mark, meaning "supported", while the `X` is "not supported".  However, this is not clear.


**What is the new behavior (if this is a feature change)?**
I've replaced the `V` with HTML checkmark entities and the `X` with HTML multiplication entities.  These render nicely in markdown and in HTML.


**Other information**:
I originally started this PR to add the missing exchanges to the import list but I see that has already been done.  The doc site needs to be updated, though.