### PR TITLE
Fix various issues with SQLITE 3 and import task shutdown

### DIFF
--- a/core/gekkoStream.js
+++ b/core/gekkoStream.js
@@ -40,7 +40,6 @@ Gekko.prototype.finalize = function() {
 }
 
 Gekko.prototype.shutdown = function() {
-  console.log("Finalizing gekko stream");
   async.eachSeries(
     this.candleConsumers,
     function(c, callback) {

--- a/core/gekkoStream.js
+++ b/core/gekkoStream.js
@@ -40,10 +40,12 @@ Gekko.prototype.finalize = function() {
 }
 
 Gekko.prototype.shutdown = function() {
+  console.log("Finalizing gekko stream");
   async.eachSeries(
     this.candleConsumers,
     function(c, callback) {
       if (c.finalize) c.finalize(callback);
+      else callback();
     },
     function() {
       // If we are a child process, we signal to the parent to kill the child once it is done

--- a/core/gekkoStream.js
+++ b/core/gekkoStream.js
@@ -3,6 +3,7 @@
 
 var Writable = require('stream').Writable;
 var _ = require('lodash');
+var async = require('async');
 
 var util = require('./util');
 var env = util.gekkoEnv();
@@ -39,15 +40,17 @@ Gekko.prototype.finalize = function() {
 }
 
 Gekko.prototype.shutdown = function() {
-  _.each(this.candleConsumers, function(c) {
-    if(c.finalize)
-      c.finalize();
-  });
-
-  // If we are a child process, we signal to the parent to kill the child once it is done
-  // so that is has time to process all remaining events (and send report data)
-  if(env === 'child-process')
-    process.send('done');
-}
+  async.eachSeries(
+    this.candleConsumers,
+    function(c, callback) {
+      if (c.finalize) c.finalize(callback);
+    },
+    function() {
+      // If we are a child process, we signal to the parent to kill the child once it is done
+      // so that is has time to process all remaining events (and send report data)
+      if (env === 'child-process') process.send('done');
+    }
+  );
+};
 
 module.exports = Gekko;

--- a/core/markets/importer.js
+++ b/core/markets/importer.js
@@ -100,7 +100,8 @@ Market.prototype.processTrades = function(trades) {
 
   if(this.done) {
     log.info('Done importing!');
-    process.exit(0);
+    this.emit('end');
+    return;
   }
 
   if(_.size(trades)) {

--- a/plugins/adviceLogger.js
+++ b/plugins/adviceLogger.js
@@ -28,8 +28,9 @@ Actor.prototype.processAdvice = function(advice) {
   console.log()
 };
 
-Actor.prototype.finalize = function(advice) {
+Actor.prototype.finalize = function(advice, done) {
   // todo
+  done();
 };
 
 module.exports = Actor;

--- a/plugins/mongodb/writer.js
+++ b/plugins/mongodb/writer.js
@@ -64,9 +64,10 @@ var processCandle = function processCandle (candle, done) {
   done();
 }
 
-var finalize = function() {
+var finalize = function(done) {
   this.writeCandles();
   this.db = null;
+  done();
 }
 
 var processAdvice = function processAdvice (advice) {

--- a/plugins/mongodb/writer.js
+++ b/plugins/mongodb/writer.js
@@ -59,8 +59,14 @@ var processCandle = function processCandle (candle, done) {
   this.marketTime = candle.start;
 
   this.candleCache.push(candle);
-  _.defer(this.writeCandles);
+  if (this.candleCache.length > 100) 
+    this.writeCandles();
   done();
+}
+
+var finalize = function() {
+  this.writeCandles();
+  this.db = null;
 }
 
 var processAdvice = function processAdvice (advice) {
@@ -89,6 +95,7 @@ if (config.adviceWriter.enabled) {
 if (config.candleWriter.enabled) {
   log.debug('Enabling candleWriter.');
   Store.prototype.processCandle = processCandle;
+  Store.prototype.finalize = finalize;
 }
 
 module.exports = Store;

--- a/plugins/performanceAnalyzer/performanceAnalyzer.js
+++ b/plugins/performanceAnalyzer/performanceAnalyzer.js
@@ -166,9 +166,10 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
   return report;
 }
 
-PerformanceAnalyzer.prototype.finalize = function() {
+PerformanceAnalyzer.prototype.finalize = function(done) {
   const report = this.calculateReportStatistics();
   this.handler.finalize(report);
+  done();
 }
 
 

--- a/plugins/postgresql/writer.js
+++ b/plugins/postgresql/writer.js
@@ -65,17 +65,21 @@ Store.prototype.writeCandles = function() {
 }
 
 var processCandle = function(candle, done) {
-
-  // because we might get a lot of candles
-  // in the same tick, we rather batch them
-  // up and insert them at once at next tick.
   this.cache.push(candle);
-  _.defer(this.writeCandles);
+  if (this.cache.length > 100) 
+    this.writeCandles();
+
   done();
+};
+
+var finalize = function() {
+  this.writeCandles();
+  this.db = null;
 }
 
-if(config.candleWriter.enabled){
+if(config.candleWriter.enabled) {
   Store.prototype.processCandle = processCandle;
+  Store.prototype.finalize = finalize;
 }
 
 module.exports = Store;

--- a/plugins/postgresql/writer.js
+++ b/plugins/postgresql/writer.js
@@ -72,9 +72,10 @@ var processCandle = function(candle, done) {
   done();
 };
 
-var finalize = function() {
+var finalize = function(done) {
   this.writeCandles();
   this.db = null;
+  done();
 }
 
 if(config.candleWriter.enabled) {

--- a/plugins/sqlite/handle.js
+++ b/plugins/sqlite/handle.js
@@ -49,7 +49,7 @@ if(mode === 'realtime' || mode === 'importer') {
     util.die(`History database does not exist for exchange ${config.watch.exchange} at version ${version}.`);
 }
 
-var journalMode = config.sqlite.journalMode || 'DELETE';
+var journalMode = config.sqlite.journalMode || 'PERSIST';
 var syncMode = journalMode === 'WAL' ? 'NORMAL' : 'FULL';
 
 var db = new sqlite3.Database(fullPath);

--- a/plugins/sqlite/handle.js
+++ b/plugins/sqlite/handle.js
@@ -49,8 +49,12 @@ if(mode === 'realtime' || mode === 'importer') {
     util.die(`History database does not exist for exchange ${config.watch.exchange} at version ${version}.`);
 }
 
+var journalMode = config.sqlite.journalMode || 'DELETE';
+var syncMode = journalMode === 'WAL' ? 'NORMAL' : 'FULL';
+
 var db = new sqlite3.Database(fullPath);
-db.run('PRAGMA journal_mode = ' + config.sqlite.journalMode||'DELETE');
+db.run('PRAGMA synchronous = ' + syncMode);
+db.run('PRAGMA journal_mode = ' + journalMode);
 db.configure('busyTimeout', 1500);
 
 module.exports = db;

--- a/plugins/sqlite/reader.js
+++ b/plugins/sqlite/reader.js
@@ -162,6 +162,7 @@ Reader.prototype.getBoundry = function(next) {
 }
 
 Reader.prototype.close = function() {
+  this.db.close();
   this.db = null;
 }
 

--- a/plugins/sqlite/scanner.js
+++ b/plugins/sqlite/scanner.js
@@ -32,7 +32,7 @@ module.exports = done => {
   async.each(dbs, (db, next) => {
 
     const exchange = _.first(db.split('_'));
-    const handle = new sqlite3.Database(dbDirectory + '/' + db, err => {
+    const handle = new sqlite3.Database(dbDirectory + '/' + db, sqlite3.OPEN_READONLY, err => {
       if(err)
         return next(err);
 

--- a/plugins/sqlite/writer.js
+++ b/plugins/sqlite/writer.js
@@ -81,14 +81,15 @@ Store.prototype.writeCandles = function() {
 }
 
 var processCandle = function(candle, done) {
-
   this.cache.push(candle);
-  this.writeCandles();
+  if (this.cache.length > 100) 
+    this.writeCandles();
 
   done();
-}
+};
 
 var finalize = function() {
+  this.writeCandles();
   this.db.close();
   this.db = null;
 }

--- a/plugins/sqlite/writer.js
+++ b/plugins/sqlite/writer.js
@@ -82,20 +82,21 @@ Store.prototype.writeCandles = function() {
 
 var processCandle = function(candle, done) {
 
-  // because we might get a lot of candles
-  // in the same tick, we rather batch them
-  // up and insert them at once at next tick.
   this.cache.push(candle);
-  _.defer(this.writeCandles);
+  this.writeCandles();
 
-  // NOTE: sqlite3 has it's own buffering, at
-  // this point we are confident that the candle will
-  // get written to disk on next tick.
   done();
 }
 
-if(config.candleWriter.enabled)
+var finalize = function() {
+  this.db.close();
+  this.db = null;
+}
+
+if(config.candleWriter.enabled) {
   Store.prototype.processCandle = processCandle;
+  Store.prototype.finalize = finalize;
+}
 
 // TODO: add storing of trades / advice?
 

--- a/plugins/sqlite/writer.js
+++ b/plugins/sqlite/writer.js
@@ -51,46 +51,53 @@ Store.prototype.writeCandles = function() {
   if(_.isEmpty(this.cache))
     return;
 
-  var stmt = this.db.prepare(`
-    INSERT OR IGNORE INTO ${sqliteUtil.table('candles')}
-    VALUES (?,?,?,?,?,?,?,?,?)
-  `, function(err, rows) {
-      if(err) {
-        log.error(err);
-        return util.die('DB error at INSERT: '+ err);
-      }
+  var transaction = function() {
+    this.db.run("BEGIN TRANSACTION");
+
+    var stmt = this.db.prepare(`
+      INSERT OR IGNORE INTO ${sqliteUtil.table('candles')}
+      VALUES (?,?,?,?,?,?,?,?,?)
+    `, function(err, rows) {
+        if(err) {
+          log.error(err);
+          return util.die('DB error at INSERT: '+ err);
+        }
+      });
+
+    _.each(this.cache, candle => {
+      stmt.run(
+        null,
+        candle.start.unix(),
+        candle.open,
+        candle.high,
+        candle.low,
+        candle.close,
+        candle.vwp,
+        candle.volume,
+        candle.trades
+      );
     });
 
-  _.each(this.cache, candle => {
-    stmt.run(
-      null,
-      candle.start.unix(),
-      candle.open,
-      candle.high,
-      candle.low,
-      candle.close,
-      candle.vwp,
-      candle.volume,
-      candle.trades
-    );
-  });
+    stmt.finalize();
+    this.db.run("COMMIT");
+    
+    this.cache = [];
+  }
 
-  stmt.finalize();
-
-  this.cache = [];
+  this.db.serialize(_.bind(transaction, this));
 }
 
 var processCandle = function(candle, done) {
   this.cache.push(candle);
-  if (this.cache.length > 100) 
+  if (this.cache.length > 1000) 
     this.writeCandles();
 
   done();
 };
 
-var finalize = function() {
+var finalize = function(done) {
   this.writeCandles();
-  this.db.close();
+  this.db.close(() => { done(); });
   this.db = null;
 }
 

--- a/sample-config.js
+++ b/sample-config.js
@@ -398,7 +398,7 @@ config.sqlite = {
   dataDirectory: 'history',
   version: 0.1,
 
-  journalMode: 'WAL', // setting this to 'DEL' may prevent db locking on windows
+  journalMode: require('../isWindows.js') ? 'PERSIST' : 'WAL',
 
   dependencies: []
 }

--- a/web/routes/baseConfig.js
+++ b/web/routes/baseConfig.js
@@ -43,7 +43,7 @@ config.sqlite = {
   path: 'plugins/sqlite',
   version: 0.1,
   dataDirectory: 'history',
-  journalMode: require('../isWindows.js') ? 'DELETE' : 'WAL',
+  journalMode: require('../isWindows.js') ? 'PERSIST' : 'WAL',
   dependencies: [{
     module: 'sqlite3',
     version: '3.1.4'


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

**BUG FIX**

* **What is the current behavior?** (You can also link to an open issue here)

I was able to spend some time dedicated to test the DB journaling changes and importing this weekend, I had a bug with low volume markets (particularly with Binance) where importing the default date range of BTC/POWR would:

1) Result in a lot of fragmented date ranges when scanning available datasets
2) Occasionally not show any results at all after import
3) Insert records into the database really slowly when using DELETE journalling

While these problems were largely only noticed in DELETE journaling due to the overhead, occasionally I could produce it with WAL if my CPU was kept busy.

* ** What is the new behaviour **

After doing a bit of research in the sqlite3 documentation, there were a couple of problems present and addressed

1) We did not call shutdown on the DB - Technically this isn't a huge problem as row operations are atomic in SQLITE 3, but since the nodejs module is async we have to use db.close to wait for a callback indicating the DB operations are completed and the DB has flushed.

2) We did not wait for the shutdown of the DB to complete. Import was calling process.exit directly. To fix this I've added a callback function to finalize which waits on the signal that the DB is flushed. Once finalization is complete gekkostream will now shutdown the process by sending the IPC request to exit like with backtesting. This will give is a singular and consistent approach to handling shutdown and ensure that the DB is ready.

3) We were not properly using transactions for inserts. The code did not use transactions at all, in this case the default behaviour for SQLITE is to automatically treat every insert as atomic which adds a lot of overhead in all journaling modes, though in WAL journalling was still fairly performant. I added calls to db.serialize and BEGIN/COMMIT for every candle batch, this made staggering improvements to insert speed (15 minutes in one test, to 5 seconds).

4) The use of _.defer(writeCandles) was potentially causing the last candle write to attempt to happen after the DB was closed. I removed the call here and instead use a counter to trigger a batch write in batches of 1000, as well as an explicit call in finalize to flush pending candles. With transactions the write time is negligible.

5) While DELETE is the default journal mode in SQLITE, I changed the mode on windows to PERSIST. The causes the journal files to stick around, but our DBs are very small and the journal files even smaller (measured in KB), this added to insert performance.

6) SQLITE generally recommends setting FULL synch mode for non-WAL journaling, this helps ensure the integrity of the database should the import process crash, WAL is by nature more robust and recommended to leave synch as NORMAL when it is being used. This is now respected.

* **Other information**:

I've done a fairly extensive amount of testing on these changes over the last 48 hours, on both OSX and Windows, using both journal modes on each system, importing and backtesting from different exchanges, and validating DB integrity by direct integrity checks through SQLITE DB BROWSER.

I have not added shutdown procedure for Mongo or Postgres. They may need to be checked in the future, however since they are not embedded solutions they are  likely to be more persistent and not be prone to the above problems anyway.
