### PR TITLE
[KRAKEN] Normalizing the approach for retry handling

### DIFF
--- a/core/error.js
+++ b/core/error.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+
+let RetryError = function(message) {
+    _.bindAll(this);
+
+    this.name = "RetryError";
+    this.message = message;
+}
+
+RetryError.prototype = new Error();
+
+let AbortError = function(message) {
+    _.bindAll(this);
+
+    this.name = "AbortError";
+    this.message = message;
+}
+
+AbortError.prototype = new Error();
+
+module.exports = {
+    'RetryError': RetryError,
+    'AbortError': AbortError
+};
+

--- a/core/util.js
+++ b/core/util.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var semver = require('semver');
 var program = require('commander');
 var retry = require('retry');
+var Errors = require('./error');
 
 var startTime = moment();
 
@@ -15,6 +16,24 @@ var _gekkoMode = false;
 var _gekkoEnv = false;
 
 var _args = false;
+
+var retryHelper = function(fn, options, callback) {
+  var operation = retry.operation(options);
+  operation.attempt(function(currentAttempt) {
+    fn(function(err, result) {
+      if (!(err instanceof Errors.AbortError) && operation.retry(err)) {
+        return;
+      }
+
+      if (err) {
+        console.log('About to throw an error along ' + operation.mainError());
+        console.log(err);
+      }
+
+      callback(err ? operation.mainError() : null, result);
+    });
+  });
+}
 
 // helper functions
 var util = {
@@ -163,23 +182,18 @@ var util = {
     return startTime;
   },
   retry: function(fn, callback) {
-    var operation = retry.operation({
+    var operation = {
       retries: 5,
       factor: 1.2,
       minTimeout: 1 * 1000,
       maxTimeout: 3 * 1000
-    });
+    };
  
-    operation.attempt(function(currentAttempt) {
-      fn(function(err, result) {
-        if (operation.retry(err)) {
-          return;
-        }
-
-        callback(err ? operation.mainError() : null, result);
-      });
-    });
-  }
+    retryHelper(fn, options, callback);
+  },
+  retryCustom: function(options, fn, callback) {
+    retryHelper(fn, options, callback);
+  },
 }
 
 // NOTE: those options are only used

--- a/core/util.js
+++ b/core/util.js
@@ -25,12 +25,7 @@ var retryHelper = function(fn, options, callback) {
         return;
       }
 
-      if (err) {
-        console.log('About to throw an error along ' + operation.mainError());
-        console.log(err);
-      }
-
-      callback(err ? operation.mainError() : null, result);
+      callback(err ? err.message : null, result);
     });
   });
 }

--- a/exchanges/kraken.js
+++ b/exchanges/kraken.js
@@ -106,7 +106,7 @@ var retryCritical = {
 var retryForever = {
   forever: true,
   factor: 1.2,
-  minTimeour: 10,
+  minTimeout: 10,
   maxTimeout: 30
 };
 
@@ -125,13 +125,15 @@ Trader.prototype.processError = function(funcName, error, alwaysRecoverable) {
 };
 
 Trader.prototype.handleResponse = function(funcName, error, body, callback) {
-  if(_.isEmpty(body) || _.isEmpty(body.result))
-    err = new Error('NO DATA WAS RETURNED');
+  if(!error) {
+    if(_.isEmpty(body) || !body.result)
+      error = new Error('NO DATA WAS RETURNED');
 
-  else if(!_.isEmpty(body.error))
-    err = new Error(body.error);
+    else if(!_.isEmpty(body.error))
+      error = new Error(body.error);
+  }
 
-  return callback(this.processError(funcName, err, true), body);
+  return callback(this.processError(funcName, error, true), body);
 };
 
 Trader.prototype.getTrades = function(since, callback, descending) {

--- a/exchanges/kraken.js
+++ b/exchanges/kraken.js
@@ -203,7 +203,7 @@ Trader.prototype.getPortfolio = function(callback) {
     return callback(undefined, portfolio);
   };
 
-  let handler = (cb) => this.kraken.api('Balance', reqData, (e,d) => this.handleResponse('getPortfolio', e, d, cb));
+  let handler = (cb) => this.kraken.api('Balance', {}, (e,d) => this.handleResponse('getPortfolio', e, d, cb));
   util.retryCustom(retryForever, _.bind(handler, this), _.bind(setBalance, this));
 };
 

--- a/exchanges/kraken.js
+++ b/exchanges/kraken.js
@@ -139,7 +139,7 @@ Trader.prototype.handleResponse = function(funcName, error, body, callback) {
 Trader.prototype.getTrades = function(since, callback, descending) {
   var startTs = since ? moment(since).valueOf() : null;
 
-  var process = function(err, trades) {
+  var processResults = function(err, trades) {
     if (err) return callback(err);
 
     var parsedTrades = [];
@@ -171,7 +171,7 @@ Trader.prototype.getTrades = function(since, callback, descending) {
   }
 
   let handler = (cb) => this.kraken.api('Trades', reqData, (e,d) => this.handleResponse('getTrades', e, d, cb));
-  util.retryCustom(retryForever, _.bind(handler, this), _.bind(process, this));
+  util.retryCustom(retryForever, _.bind(handler, this), _.bind(processResults, this));
 };
 
 Trader.prototype.getPortfolio = function(callback) {

--- a/exchanges/kraken.js
+++ b/exchanges/kraken.js
@@ -112,10 +112,10 @@ var retryForever = {
 
 var recoverableErrors = new RegExp(/(SOCKETTIMEDOUT|TIMEDOUT|CONNRESET|CONNREFUSED|NOTFOUND|API:Invalid nonce|Service:Unavailable|Request timed out|Response code 520|Response code 504|Response code 502)/)
 
-Trader.prototype.processError = function(funcName, error, alwaysRecoverable) {
+Trader.prototype.processError = function(funcName, error) {
   if (!error) return undefined;
 
-  if (!alwaysRecoverable && !error.message.match(recoverableErrors)) {
+  if (!error.message.match(recoverableErrors)) {
     log.error(`[kraken.js] (${funcName}) returned an irrecoverable error: ${error.message}`);
     return new Errors.AbortError(error.message);
   }
@@ -133,7 +133,7 @@ Trader.prototype.handleResponse = function(funcName, error, body, callback) {
       error = new Error(body.error);
   }
 
-  return callback(this.processError(funcName, error, true), body);
+  return callback(this.processError(funcName, error), body);
 };
 
 Trader.prototype.getTrades = function(since, callback, descending) {

--- a/importers/exchanges/kraken.js
+++ b/importers/exchanges/kraken.js
@@ -1,8 +1,10 @@
 var KrakenClient = require('kraken-api-es5')
-var util = require('../../core/util.js');
 var _ = require('lodash');
 var moment = require('moment');
+
+var util = require('../../core/util.js');
 var log = require('../../core/log');
+var Errors = require('../../core/error.js')
 
 var config = util.getConfig();
 
@@ -26,10 +28,10 @@ var fetch = () => {
 
     if (lastId) {
         var tidAsTimestamp = lastId / 1000000;
-        fetcher.getTrades(tidAsTimestamp, handleFetch);
+        util.retryForever((cb) => fetcher.getTrades(tidAsTimestamp, cb), handleFetch);
     }
     else
-        fetcher.getTrades(from, handleFetch);
+        util.retryForever((cb) => fetcher.getTrades(from, cb), handleFetch);
 }
 
 var handleFetch = (unk, trades) => {

--- a/importers/exchanges/kraken.js
+++ b/importers/exchanges/kraken.js
@@ -28,10 +28,10 @@ var fetch = () => {
 
     if (lastId) {
         var tidAsTimestamp = lastId / 1000000;
-        util.retryForever((cb) => fetcher.getTrades(tidAsTimestamp, cb), handleFetch);
+        fetcher.getTrades(tidAsTimestamp, handleFetch);
     }
     else
-        util.retryForever((cb) => fetcher.getTrades(from, cb), handleFetch);
+        fetcher.getTrades(from, handleFetch);
 }
 
 var handleFetch = (unk, trades) => {

--- a/plugins/trader/portfolioManager.js
+++ b/plugins/trader/portfolioManager.js
@@ -104,7 +104,7 @@ Manager.prototype.setPortfolio = function(callback) {
 
   }.bind(this);
 
-  util.retry(this.exchange.getPortfolio, set);
+  this.exchange.getPortfolio(set);
 };
 
 Manager.prototype.setFee = function(callback) {
@@ -117,7 +117,7 @@ Manager.prototype.setFee = function(callback) {
     if(_.isFunction(callback))
       callback();
   }.bind(this);
-  util.retry(this.exchange.getFee, set);
+  this.exchange.getFee(set);
 };
 
 Manager.prototype.setTicker = function(callback) {
@@ -130,7 +130,7 @@ Manager.prototype.setTicker = function(callback) {
     if(_.isFunction(callback))
       callback();
   }.bind(this);
-  util.retry(this.exchange.getTicker, set);
+  this.exchange.getTicker(set);
 };
 
 // return the [fund] based on the data we have in memory


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature, will probably fix some bugs though

* **What is the current behavior?** (You can also link to an open issue here)

Currently retry handling is implemented by the individual exchanges, and so isn't very consistent. Depending on the implementation, some exchanges have irrecoverable errors to solve issues like API errors causing orders cancels to never end, others impement them in different functions. In Kraken, for instance, there was no retry handling on getTicker, but some other exchanges do implement this. 

* **What is the new behavior (if this is a feature change)?**

Also recent work (6 months ago) @askmike started to add retry handling directly in the portfolioManager. This is implemented fairly easily using the "retry" package which comes with feature not otherwise handled by our per exchange implementation, such as limiting the number of retries and exponential backoff of the retry delay.

In this PR I extended that functionality to all exchange functions, and was able to drop retry handling from kraken completely.

This approach is also fully compatible with exchange that currently have their own retry handling, so there is no need to update all the exchange implementations until someone is ready to test them.

This should help simplify the implementation and debugging of exchanges going forward.

* **Other information**:

Kraken's service is in such a state is disrepair right now that it was a convenient place to test the retry handlers worked correctly. Through various actions, importing, paper trading the recoverable errors are caught and dispatched through the retry handler as expected.