### PR TITLE
Adds error type: MIN_TRADE_REQUIREMENT_NOT_MET

### DIFF
--- a/exchanges/bittrex.js
+++ b/exchanges/bittrex.js
@@ -184,6 +184,7 @@ Trader.prototype.buy = function(amount, price, callback) {
         callback(null, 'dummyOrderId');
         return;
       } else if (err && err.message === 'MIN_TRADE_REQUIREMENT_NOT_MET') {
+        callback(null, 'dummyOrderId');
         log.error('Error buy ' , 'MIN_TRADE_REQUIREMENT_NOT_MET', err );
         return;
       }

--- a/exchanges/bittrex.js
+++ b/exchanges/bittrex.js
@@ -184,8 +184,8 @@ Trader.prototype.buy = function(amount, price, callback) {
         callback(null, 'dummyOrderId');
         return;
       } else if (err && err.message === 'MIN_TRADE_REQUIREMENT_NOT_MET') {
-        callback(null, 'dummyOrderId');
         log.error('Error buy ' , 'MIN_TRADE_REQUIREMENT_NOT_MET', err );
+        callback(null, 'dummyOrderId');
         return;
       }
       log.error('unable to buy:', {err: err, result: result});

--- a/exchanges/bittrex.js
+++ b/exchanges/bittrex.js
@@ -183,6 +183,9 @@ Trader.prototype.buy = function(amount, price, callback) {
       } else if (err && err.message === 'DUST_TRADE_DISALLOWED_MIN_VALUE_50K_SAT') {
         callback(null, 'dummyOrderId');
         return;
+      } else if (err && err.message === 'MIN_TRADE_REQUIREMENT_NOT_MET') {
+        log.error('Error buy ' , 'MIN_TRADE_REQUIREMENT_NOT_MET', err );
+        return;
       }
       log.error('unable to buy:', {err: err, result: result});
       return this.retry(this.buy, args);


### PR DESCRIPTION
This add's the "minimum funds not available" error type from the bittrex exchange so that when this error is received, gekko doesn't continue looping/attempting to retry();. If the minimum funds aren't available, gekko shouldn't continue to retry.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds 'MIN_TRADE_REQUIREMENT_NOT_MET' error type for the bittrex exchange.


* **What is the current behavior?** (You can also link to an open issue here)
When this error is received by gekko, gekko continues to retry() ordering.


* **What is the new behavior (if this is a feature change)?**
If this error is recieved by gekko, gekko doesn't continue to retry() ordering and instead only logs it as an error. If minimum trade requirement isn't met, it doesn't make sense to continue retrying();. 

* **Other information**:
