### PR TITLE
Update home.vue

### DIFF
--- a/web/vue/src/components/layout/home.vue
+++ b/web/vue/src/components/layout/home.vue
@@ -2,7 +2,7 @@
   section.contain.grd-row
     .grd-row-col-3-6(v-html='left')
     .grd-row-col-3-6.txt--center
-      img(src='/assets/gekko.jpg')
+      img(src='./assets/gekko.jpg')
       p
         em The most valuable commodity I know of is information.
 </template>


### PR DESCRIPTION
fix src for dynamically update gekko.jpg location to match with non-standard path names.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

currently gekko will always look for gekko.jpg in /asset/gekko.jpg
#1484 

* **What is the new behavior (if this is a feature change)?**

Will dynamically update location of the asset folder to match nonstandard paths

* **Other information**:
