### PR TITLE
Fix sqlite writing candles with low vol markets in realtime

### DIFF
--- a/plugins/sqlite/writer.js
+++ b/plugins/sqlite/writer.js
@@ -53,6 +53,9 @@ Store.prototype.writeCandles = function() {
     return;
 
   var transaction = function() {
+    if (!this.cache.length)
+      return;
+      
     this.db.run("BEGIN TRANSACTION");
 
     var stmt = this.db.prepare(`


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

When leeching a market and writing the candles, a reporting period with no candle still dispatched the candle to the writer which pretty much does nothing. However this can cause SQLITE_CORRUPTED errors to be thrown by other processes trying to read data at the same time.

Even though this error occurs I've been able to open, and run `pragma integrity_check` on the DB with no issues, restarting doesn't seem to be a problem either. None the less, we should fix this.

* **What is the new behavior (if this is a feature change)?**

Simple check that there is candle data to write before trying, if not don't open the transaction.

* **Other information**:
