### PR TITLE
Handle rejected promises

### DIFF
--- a/core/budfox/marketFetcher.js
+++ b/core/budfox/marketFetcher.js
@@ -91,7 +91,7 @@ Fetcher.prototype.fetch = function() {
 Fetcher.prototype.processTrades = function(err, trades) {
   if(err || _.isEmpty(trades)) {
     if(err) {
-      log.warn(this.exhange.name, 'returned an error while fetching trades:', err);
+      log.warn(this.exchange.name, 'returned an error while fetching trades:', err);
       log.debug('refetching...');
     } else
       log.debug('Trade fetch came back empty, refetching...');

--- a/gekko.js
+++ b/gekko.js
@@ -32,6 +32,7 @@ console.log(`
    $$$$$$/  $$$$$$$$/ $$/   $$/ $$/   $$/  $$$$$$/
 `);
 
+const log = require(__dirname + '/core/log');
 const util = require(__dirname + '/core/util');
 
 console.log('\tGekko v' + util.getVersion());
@@ -59,3 +60,7 @@ pipeline({
   mode: mode
 });
 
+process.on('unhandledRejection', (reason, p) => {
+  log.error(`Unhandled Rejection at: ${p}, Reason: ${reason}`);
+  // application specific logging, throwing an error, or other logic here
+});


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix to handle rejected promises in case of spelling errors or APIs returning bad data. 


* **What is the current behavior?** (You can also link to an open issue here)
When the marketFetcher received a warning and tries to log to the console, it finds a misspelt variable and throws rejection


* **What is the new behavior (if this is a feature change)?**
Fixes the spelling mistake and adds a listener to `gekko.js` to catch any other unhandled promises.   This listener only logs to the console for now.


* **Other information**:
Happy for the unhandledRejection process listener to be dumped but it will be worthwhile going forward when most people catch up with the latest node versions.  In future node versions, the process will exit on unhandled rejections. 