### PR TITLE
Fix moment utc format

### DIFF
--- a/plugins/mongodb/writer.js
+++ b/plugins/mongodb/writer.js
@@ -33,7 +33,7 @@ Store.prototype.writeCandles = function writeCandles () {
   var candles = [];
   _.each(this.candleCache, candle => {
     var mCandle = {
-      time: moment().utc(),
+      time: moment().unix(),
       start: candle.start.unix(),
       open: candle.open,
       high: candle.high,
@@ -77,7 +77,7 @@ var processAdvice = function processAdvice (advice) {
 
   log.debug(`Writing advice '${advice.recommendation}' to database.`);
   var mAdvice = {
-    time: moment().utc(),
+    time: moment().unix(),
     marketTime: this.marketTime,
     pair: this.pair,
     recommendation: advice.recommendation,


### PR DESCRIPTION
Store moment utc as a string rather than a serialized moment object in mongodb.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: moment is being serialized and stored in mongo

* **What is the current behavior?** (You can also link to an open issue here)
`moment().utc()` is being serialized and stored in mongodb

* **What is the new behavior (if this is a feature change)?**
Changed to `moment().utc().format()` so we get a string of the datetime.


* **Other information**:
Reported here: https://github.com/askmike/gekko/issues/1632 