### PR TITLE
fix watchconfig not reading user selection

### DIFF
--- a/web/vue/src/components/gekko/new.vue
+++ b/web/vue/src/components/gekko/new.vue
@@ -34,7 +34,7 @@ export default {
     watchConfig: function() {
       let raw = _.pick(this.config, 'watch', 'candleWriter');
       let watchConfig = Vue.util.extend({}, raw);
-      watchConfig.type = 'market watcher';
+      watchConfig.type = this.config.type;
       watchConfig.mode = 'realtime';
       return watchConfig;
     },


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix

* **What is the current behavior?** (You can also link to an open issue here)

add live gekko and select the type wont work, always "market watcher".

* **What is the new behavior (if this is a feature change)?**
the config type will change based on user's selection.


* **Other information**:
