### PR TITLE
Fix Bitfinex import

### DIFF
--- a/importers/exchanges/bitfinex.js
+++ b/importers/exchanges/bitfinex.js
@@ -55,6 +55,10 @@ var batch_start = false;
 var batch_end = false;
 var batch_last = false;
 
+const SCANNING_STRIDE = 24;
+const ITERATING_STRIDE = 2;
+var stride = ITERATING_STRIDE;
+
 var fetcher = new Fetcher(config.watch);
 fetcher.bitfinex = new Bitfinex(null, null, { version: 2, transform: true }).rest;
 


### PR DESCRIPTION
This adds back missing constants for the Bitfinex importer. They were the only things that appeared missing from updates, possible a bad merge somewhere a long the way.