### PR TITLE
Subtract candle length from start time to calculate isPremature

### DIFF
--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -224,11 +224,11 @@ Base.prototype.propogateTick = function(candle) {
   // whether candle start time is > startTime
   var isPremature;
 
-  // Subtract number of minutes in current candle for instant start
-  let startTimeMinusCandleSize = startTime.clone();
-  startTimeMinusCandleSize.subtract(this.tradingAdvisor.candleSize, "minutes"); 
-
   if(mode === 'realtime'){
+    // Subtract number of minutes in current candle for instant start
+    let startTimeMinusCandleSize = startTime.clone();
+    startTimeMinusCandleSize.subtract(this.tradingAdvisor.candleSize, "minutes"); 
+    
     isPremature = candle.start < startTimeMinusCandleSize;
   }
   else{

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -223,10 +223,17 @@ Base.prototype.propogateTick = function(candle) {
   // than minimally needed. In that case check
   // whether candle start time is > startTime
   var isPremature;
-  if(mode === 'realtime')
-    isPremature = candle.start < startTime;
-  else
+
+  // Subtract number of minutes in current candle for instant start
+  let startTimeMinusCandleSize = startTime.clone();
+  startTimeMinusCandleSize.subtract(this.tradingAdvisor.candleSize, "minutes"); 
+
+  if(mode === 'realtime'){
+    isPremature = candle.start < startTimeMinusCandleSize;
+  }
+  else{
     isPremature = false;
+  }
 
   if(isAllowedToCheck && !isPremature) {
     this.log(candle);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix / feature

* **What is the current behavior?** (You can also link to an open issue here)
Gekko wasn't starting to trade on the first live candle, it was delaying a full candle before starting trades on the live market.

* **What is the new behavior (if this is a feature change)?**
This causes it to start trading on the first live candle.

* **Other information**:
More info at : https://github.com/askmike/gekko/issues/1689#issuecomment-360933359
