### PR TITLE
Use declared var instead of undefined

### DIFF
--- a/core/util.js
+++ b/core/util.js
@@ -183,8 +183,8 @@ var util = {
       minTimeout: 1 * 1000,
       maxTimeout: 3 * 1000
     };
- 
-    retryHelper(fn, operation, callback);
+
+    retryHelper(fn, options, callback);
   },
   retryCustom: function(options, fn, callback) {
     retryHelper(fn, options, callback);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The variable `options` is unused.
The undefined `operation` is used instead


* **What is the new behavior (if this is a feature change)?**
The `options` variable is now used correctly



* **Other information**:
