### PR TITLE
Fix Binance ICX/BNB minial order amount is 1

### DIFF
--- a/exchanges/binance-markets.json
+++ b/exchanges/binance-markets.json
@@ -1557,7 +1557,7 @@
         "ICX"
       ],
       "minimalOrder": {
-        "amount": 0.01,
+        "amount": 1,
         "price": 0.00001,
         "order": 1
       }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix Binance ICX/BNB minial order amount is 1


* **What is the current behavior?** (You can also link to an open issue here)
Current amount is 0.01


* **What is the new behavior (if this is a feature change)?**
Current amount is 1


* **Other information**:
Fix strat stop when try to sell under 1 ICX