### PR TITLE
Allow correct print of Entryr/Exit for exchanges that use millisecond time stamps

### DIFF
--- a/web/vue/src/components/backtester/result/roundtripTable.vue
+++ b/web/vue/src/components/backtester/result/roundtripTable.vue
@@ -36,7 +36,7 @@ export default {
   methods: {
     diff: n => moment.duration(n).humanize(),
     humanizeDuration: (n) => window.humanizeDuration(n),
-    fmt: mom => moment.utc(mom).format('YYYY-MM-DD HH:mm'),
+    fmt: mom => moment(mom).utc().format('YYYY-MM-DD HH:mm'),
     round: n => (+n).toFixed(3),
   },
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enhancement  to allow table to show correct entry and exit times for Binance and other exchanges that use milisecond timestamps


* **What is the current behavior?** (You can also link to an open issue here)
Incorrect display of time stamps when exchange is Binance or any other exchange that uses millisecond timestamps


* **What is the new behavior (if this is a feature change)?**
Correct display of time stamps when exchange is Binance or any other exchange that uses millisecond timestamps


* **Other information**:
