### PR TITLE
Revert "Fix to date in emitted trades", fix #1862

### DIFF
--- a/plugins/trader/portfolioManager.js
+++ b/plugins/trader/portfolioManager.js
@@ -344,10 +344,10 @@ Manager.prototype.relayOrder = function(done) {
 
     var price = 0;
     var amount = 0;
-    var date = moment().unix();
+    var date = moment(0);
 
     _.each(res.filter(o => !_.isUndefined(o) && o.amount), order => {
-      date = _.max([moment(order.date).unix(), date]);
+      date = _.max([moment(order.date), date]);
       price = ((price * amount) + (order.price * order.amount)) / (order.amount + amount);
       amount += +order.amount;
     });


### PR DESCRIPTION
This reverts commit 2a07c609f3da1629c3e585f702e743f4488dd7ca, see #1862 for details.