### PR TITLE
Improve Binance getTicker log entry

### DIFF
--- a/exchanges/binance.js
+++ b/exchanges/binance.js
@@ -115,7 +115,7 @@ Trader.prototype.getTrades = function(since, callback, descending) {
 
 Trader.prototype.getPortfolio = function(callback) {
   var setBalance = function(err, data) {
-    log.debug(`[binance.js] entering "setBalance" callback after api call, err: ${err}, data: ${data}`)
+    log.debug(`[binance.js] entering "setBalance" callback after api call, err: ${err} data: ${JSON.stringify(data)}`)
     if (err) return callback(err);
 
     var findAsset = function(item) {
@@ -162,7 +162,7 @@ Trader.prototype.getFee = function(callback) {
 
 Trader.prototype.getTicker = function(callback) {
   var setTicker = function(err, data) {
-    log.debug(`[binance.js] entering "getTicker" callback after api call, err: ${err} data: ${JSON.stringify(data)}`);
+    log.debug(`[binance.js] entering "getTicker" callback after api call, err: ${err} data: ${(data || []).length} symbols`);
     if (err) return callback(err);
 
     var findSymbol = function(ticker) {


### PR DESCRIPTION
Resolves [#1953](https://github.com/askmike/gekko/issues/1953)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Log improvements


* **What is the current behavior?** (You can also link to an open issue here)
1. Binance log code consistency.
2. Binance getTicker call logs the full response from API causing too much noise in log files.


* **What is the new behavior (if this is a feature change)?**
The getTicker call logs how many symbols were loaded.


* **Other information**:
