### PR TITLE
fixing candle writer

### DIFF
--- a/plugins/postgresql/reader.js
+++ b/plugins/postgresql/reader.js
@@ -175,7 +175,7 @@ Reader.prototype.getBoundry = function(next) {
 }
 
 Reader.prototype.close = function() {
-  this.db.end();
+  //this.db.end();
 }
 
 module.exports = Reader;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It fixes the candle-writer for livebots.

* **What is the current behavior?** (You can also link to an open issue here)

When a livebot is startet (via cli), it fetches the local dataset and tries to stich it with the exchange data. The reader ends the DB connection once it's done reading and the candle writer fails silently, since the db connection is already closed by the reader.


* **What is the new behavior (if this is a feature change)?**

The connetion stays open
