### PR TITLE
Add total exposure percentage to Performance Analyzer

### DIFF
--- a/plugins/performanceAnalyzer/logger.js
+++ b/plugins/performanceAnalyzer/logger.js
@@ -104,6 +104,7 @@ if(mode === 'backtest') {
     log.info(`(PROFIT REPORT) timespan:\t\t\t ${report.timespan}`);
     if(report.sharpe)
       log.info(`(PROFIT REPORT) sharpe ratio:\t\t\t ${report.sharpe}`);
+    log.info(`(PROFIT REPORT) exposure:\t\t\t ${report.exposure}`);
     log.info();
     log.info(`(PROFIT REPORT) start price:\t\t\t ${report.startPrice} ${this.currency}`);
     log.info(`(PROFIT REPORT) end price:\t\t\t ${report.endPrice} ${this.currency}`);

--- a/plugins/performanceAnalyzer/performanceAnalyzer.js
+++ b/plugins/performanceAnalyzer/performanceAnalyzer.js
@@ -36,6 +36,8 @@ const PerformanceAnalyzer = function() {
 
   this.sharpe = 0;
 
+  this.exposure = 0;
+
   this.roundTrips = [];
   this.roundTrip = {
     id: 0,
@@ -136,6 +138,8 @@ PerformanceAnalyzer.prototype.handleRoundtrip = function() {
     this.roundTrips.map(r => r.profit),
     perfConfig.riskFreeReturn
   );
+  // update cached exposure
+  this.exposure = this.exposure + Date.parse(this.roundTrip.exit.date) - Date.parse(this.roundTrip.entry.date);
 }
 
 PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
@@ -147,6 +151,7 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
     this.dates.end.diff(this.dates.start)
   );
   let relativeProfit = balance / this.start.balance * 100 - 100
+  let percentExposure = this.exposure / (Date.parse(this.dates.end) - Date.parse(this.dates.start));
 
   let report = {
     currency: this.currency,
@@ -168,7 +173,8 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
     endPrice: this.endPrice,
     trades: this.trades,
     startBalance: this.start.balance,
-    sharpe: this.sharpe
+    sharpe: this.sharpe,
+    exposure: percentExposure
   }
 
   report.alpha = report.profit - report.market;


### PR DESCRIPTION
This patch adds total exposure as a percentage to Performance Analyzer.

The logger reports the exposure as a number between 0 and 1, depending on how much time is spent in trades. an exposure of 1 means the asset is bought immediately and never sold, an exposure of 0 means the asset is never bought. A lower total exposure may indicate a lower risk strategy when weighed against profit and/or sharpe ratio.

I think this could be a useful stat for optimization in general, but plan on referring to it specifically in gekkoga. I've been using this to help optimizing in gekkoga and find it quite helpful for my strategy, so I thought I'd add it here (and then patch gekkoga if it gets merged.)