### PR TITLE
Fix candle history warmup to work when no data has been imported

### DIFF
--- a/core/tools/dataStitcher.js
+++ b/core/tools/dataStitcher.js
@@ -81,14 +81,16 @@ Stitcher.prototype.prepareHistoricalData = function(done) {
       var secondsOverlap = 60 * 15; // 15 minutes
       var idealExchangeStartTimeTS = localData.to - secondsOverlap;
       var idealExchangeStartTime = moment.unix(idealExchangeStartTimeTS).utc();
-
-      // already set the
-      util.setConfigProperty(
-        'tradingAdvisor',
-        'firstFetchSince',
-        idealExchangeStartTimeTS
-      );
     }
+
+    // Make it so that the market fetcher starts fetching from the time we just
+    // calculated.  This ensures that the trades flow through the entire
+    // pipeline.
+    util.setConfigProperty(
+      'tradingAdvisor',
+      'firstFetchSince',
+      idealExchangeStartTimeTS
+    );
 
     // Limit the history Gekko can try to get from the exchange.
     var minutesAgo = endTime.diff(idealExchangeStartTime, 'minutes');


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Steps to reproduce:

1. Choose a market you have not imported any data for.
2. Set candleSize to 1 and historySize to 10 in config.js.
2. Run live from CLI using a strategy that logs during `update()`.  (No talib or tulip indicators.  This has nothing to do with async.)

I expect the strategy to log 10 times immediately using recent historical candle data fetched from the exchange.  But what actually happens is that it doesn't log immediately.  I assume that it takes 10 minutes to log 10 times.

Note: if you've imported data for this exchange/currency/asset, the behavior is different and works in certain cases.

* **What is the new behavior (if this is a feature change)?**

This branch makes it so that you do not need to import data in order to run a strategy live and have it start giving advice immediately.  The recent trade/candle history is fetched from the exchange to warm up the strategy.

* **Other information**:

I tested on GDAX.  Not sure if that's relevant.