### PR TITLE
Correct typographical error in asset name

### DIFF
--- a/exchanges/gemini.js
+++ b/exchanges/gemini.js
@@ -215,7 +215,7 @@ Trader.getCapabilities = function () {
     markets: [
       
         { pair: ['USD', 'BTC'], minimalOrder: { amount: 0.01, unit: 'asset' } },
-        { pair: ['USD', 'ETC'], minimalOrder: { amount: 0.01, unit: 'asset' } },
+        { pair: ['USD', 'ETH'], minimalOrder: { amount: 0.01, unit: 'asset' } },
         { pair: ['BTC', 'ETH'], minimalOrder: { amount: 0.01, unit: 'asset' } },
 
     ],


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Correct typographical error, solving bug #2115 "Invalid options for Gemini exchange assets -- ETC instead of ETH" 

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/askmike/gekko/issues/2115


* **What is the new behavior (if this is a feature change)?**



* **Other information**:
