### PR TITLE
Set docker entrypoint to run gekko by default and use options in cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,4 @@ EXPOSE 3000
 RUN chmod +x /usr/src/app/docker-entrypoint.sh
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
 
-
-CMD [ "npm", "start" ]
+CMD ["--config", "config.js", "--ui"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,4 @@
 sed -i 's/127.0.0.1/0.0.0.0/g' /usr/src/app/web/vue/UIconfig.js
 sed -i 's/localhost/'${HOST}'/g' /usr/src/app/web/vue/UIconfig.js
 sed -i 's/3000/'${PORT}'/g' /usr/src/app/web/vue/UIconfig.js
-exec "$@"
+exec node gekko "$@"


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
feature

* **What is the current behavior?**
When running a container in another mode than `--ui` we need to specifiy the base command again (`node gekko`).

* **What is the new behavior (if this is a feature change)?**
When running the container in another mode we just need to specify the custom options. The default behavior is unchanged and will run the ui by default.