### PR TITLE
Fix minimum error

### DIFF
--- a/plugins/trader/trade.js
+++ b/plugins/trader/trade.js
@@ -307,9 +307,9 @@ class Trade{
 
   getMinimum(price) {
     if(this.minimalOrder.unit === 'currency')
-      return minimum = this.minimalOrder.amount / price;
+      return this.minimalOrder.amount / price;
     else
-      return minimum = this.minimalOrder.amount;
+      return this.minimalOrder.amount;
   }
 }
 


### PR DESCRIPTION
Sorry for opening another PR for this, but I can't seem to understand how Git works and forgot to put this on an different branch ;)

#2106, #2083

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixing error message due to syntax error in function `getMinimum()`

```
C:\gekko\plugins\trader\trade.js:310
      return minimum = this.minimalOrder.amount / price;
                     ^

ReferenceError: minimum is not defined
    at Trade.getMinimum (C:\gekko\plugins\trader\trade.js:310:22)
    at Trade.buy (C:\gekko\plugins\trader\trade.js:140:22)
    at act (C:\gekko\plugins\trader\trade.js:83:18)
    at C:\gekko\node_modules\async\dist\async.js:3853:9
    at C:\gekko\node_modules\async\dist\async.js:484:16
    at replenish (C:\gekko\node_modules\async\dist\async.js:1025:25)
    at iterateeCallback (C:\gekko\node_modules\async\dist\async.js:1015:17)
    at C:\gekko\node_modules\async\dist\async.js:988:16
    at C:\gekko\node_modules\async\dist\async.js:3850:13
    at apply (C:\gekko\node_modules\async\dist\async.js:41:25)
```

* **What is the current behavior?** (You can also link to an open issue here)
An error is thrown.

* **What is the new behavior (if this is a feature change)?**
The minimum-amount is returned correctly... ;)

* **Other information**:
I finally had time to fork and open this PR :)