### PR TITLE
Fixed QuadrigaCX market detection of outstanding orders

### DIFF
--- a/exchanges/quadriga.js
+++ b/exchanges/quadriga.js
@@ -187,7 +187,7 @@ Trader.prototype.getOrder = function(order, callback) {
     callback(undefined, {price, amount, date});
   }.bind(this);
 
-  this.quadriga.api('lookup_oder', {id: order}, get);
+  this.quadriga.api('lookup_order', {id: order}, get);
 }
 
 Trader.prototype.buy = function(amount, price, callback) {


### PR DESCRIPTION
- Fixed an error in the getOrder function where it was using lookup_oder instead of lookup_order as the remote path