### PR TITLE
Quadriga market fixes

### DIFF
--- a/exchanges/quadriga-markets.json
+++ b/exchanges/quadriga-markets.json
@@ -1,0 +1,136 @@
+{
+  "assets": [
+    "XBT",
+    "ETH",
+    "LTC",
+    "BCH",
+    "BTG"
+  ],
+  "currencies": [
+    "CAD",
+    "USD",
+    "XBT"
+  ],
+  "markets": [
+    {
+      "pair": [
+        "CAD",
+        "XBT"
+      ],
+      "book": "btc_cad",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "USD",
+        "XBT"
+      ],
+      "book": "btc_usd",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "CAD",
+        "BCH"
+      ],
+      "book": "bch_cad",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "XBT",
+        "BCH"
+      ],
+      "book": "bch_btc",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "CAD",
+        "ETH"
+      ],
+      "book": "eth_cad",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "XBT",
+        "ETH"
+      ],
+      "book": "eth_btc",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "CAD",
+        "LTC"
+      ],
+      "book": "ltc_cad",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "XBT",
+        "LTC"
+      ],
+      "book": "ltc_btc",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "CAD",
+        "BTG"
+      ],
+      "book": "btg_cad",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    },
+    {
+      "pair": [
+        "XBT",
+        "BTG"
+      ],
+      "book": "btg_btc",
+      "minimalOrder": {
+        "amount": "0.0005",
+        "unit": "asset"
+      },
+      "precision": 8
+    }
+  ]
+}

--- a/exchanges/quadriga.js
+++ b/exchanges/quadriga.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 
 const util = require('../core/util');
 const log = require('../core/log');
+const marketData = require('./quadriga-markets.json');
 
 var Trader = function(config) {
   _.bindAll(this);
@@ -231,16 +232,9 @@ Trader.getCapabilities = function () {
   return {
     name: 'Quadriga',
     slug: 'quadriga',
-    currencies: ['CAD', 'USD', 'BTC'],
-    assets: ['BTC', 'ETH', 'LTC', 'BCH'],
-    markets: [
-      { pair: ['BTC', 'ETH'], minimalOrder: { amount: 0.00001, unit: 'asset' }, precision: 8 },
-      { pair: ['CAD', 'ETH'], minimalOrder: { amount: 0.00001, unit: 'asset' }, precision: 8 },
-      { pair: ['USD', 'BTC'], minimalOrder: { amount: 0.00001, unit: 'asset' }, precision: 8 },
-      { pair: ['CAD', 'BTC'], minimalOrder: { amount: 0.00001, unit: 'asset' }, precision: 8 },
-      { pair: ['CAD', 'LTC'], minimalOrder: { amount: 0.00001, unit: 'asset' }, precision: 8 },
-      { pair: ['CAD', 'BCH'], minimalOrder: { amount: 0.00001, unit: 'asset' }, precision: 8 },
-    ],
+    currencies: marketData.currencies,
+    assets: marketData.assets,
+    markets: marketData.markets,
     requires: ['key', 'secret', 'username'],
     providesHistory: false,
     tid: 'tid',

--- a/exchanges/quadriga.js
+++ b/exchanges/quadriga.js
@@ -13,14 +13,18 @@ var Trader = function(config) {
     this.key = config.key;
     this.secret = config.secret;
     this.clientId = config.username;
-    this.asset = config.asset;
-    this.currency = config.currency;
+    this.asset = config.asset.toUpperCase();
+    this.currency = config.currency.toUpperCase();
   }
-    
-  this.pair = this.asset.toLowerCase() + '_' + this.currency.toLowerCase(); 
+  
   this.name = 'quadriga';
   this.since = null;
 
+  this.market = _.find(Trader.getCapabilities().markets, (market) => {
+    return market.pair[0] === this.currency && market.pair[1] === this.asset
+  });
+  this.pair = this.market.book;
+  
   this.quadriga = new QuadrigaCX(
     this.clientId ? this.clientId : "1",
     this.key ? this.key : "",

--- a/exchanges/quadriga.js
+++ b/exchanges/quadriga.js
@@ -1,9 +1,9 @@
-var QuadrigaCX = require('quadrigacx');
-var moment = require('moment');
-var util = require('../core/util');
-var _ = require('lodash');
-var log = require('../core/log');
+const QuadrigaCX = require('quadrigacx');
+const moment = require('moment');
+const _ = require('lodash');
 
+const util = require('../core/util');
+const log = require('../core/log');
 
 var Trader = function(config) {
   _.bindAll(this);


### PR DESCRIPTION
- Updated the supported markets and moved them to a separate JSON file with an order book
- Applied a proper fix for the uppercase currencies vs Quadriga order book format because there was inconsistencies between the Quadriga page using XBT/CAD which has order book btc_cad