### PR TITLE
Performance Analyzer fixes and features

### DIFF
--- a/plugins/performanceAnalyzer/logger.js
+++ b/plugins/performanceAnalyzer/logger.js
@@ -94,8 +94,7 @@ if(mode === 'backtest') {
     log.info(`(PROFIT REPORT) start time:\t\t\t ${report.startTime}`);
     log.info(`(PROFIT REPORT) end time:\t\t\t ${report.endTime}`);
     log.info(`(PROFIT REPORT) timespan:\t\t\t ${report.timespan}`);
-    log.info(`(PROFIT REPORT) exposure:\t\t\t ${report.exposure}%`);
-    log.info(`(PROFIT REPORT) efficiency:\t\t\t ${report.efficiency}%`);
+    log.info(`(PROFIT REPORT) exposure:\t\t\t ${report.exposure}`);
     log.info();
     log.info(`(PROFIT REPORT) start price:\t\t\t ${report.startPrice} ${this.currency}`);
     log.info(`(PROFIT REPORT) end price:\t\t\t ${report.endPrice} ${this.currency}`);

--- a/plugins/performanceAnalyzer/logger.js
+++ b/plugins/performanceAnalyzer/logger.js
@@ -94,8 +94,8 @@ if(mode === 'backtest') {
     log.info(`(PROFIT REPORT) start time:\t\t\t ${report.startTime}`);
     log.info(`(PROFIT REPORT) end time:\t\t\t ${report.endTime}`);
     log.info(`(PROFIT REPORT) timespan:\t\t\t ${report.timespan}`);
-    if(report.sharpe)
-      log.info(`(PROFIT REPORT) sharpe ratio:\t\t\t ${report.sharpe}`);
+    log.info(`(PROFIT REPORT) exposure:\t\t\t ${report.exposure}%`);
+    log.info(`(PROFIT REPORT) efficiency:\t\t\t ${report.efficiency}%`);
     log.info();
     log.info(`(PROFIT REPORT) start price:\t\t\t ${report.startPrice} ${this.currency}`);
     log.info(`(PROFIT REPORT) end price:\t\t\t ${report.endPrice} ${this.currency}`);
@@ -109,8 +109,11 @@ if(mode === 'backtest') {
       `(PROFIT REPORT) simulated yearly profit:\t ${report.yearlyProfit}`,
       `${this.currency} (${report.relativeYearlyProfit}%)`
     );
+  
+    log.info(`(PROFIT REPORT) sharpe ratio:\t\t\t ${report.sharpe}`);
+    log.info(`(PROFIT REPORT) expected downside:\t\t ${report.downside}`);
   }
-
+  
   Logger.prototype.handleRoundtrip = function(rt) {
     this.roundtrips.push(rt);
   }

--- a/plugins/performanceAnalyzer/performanceAnalyzer.js
+++ b/plugins/performanceAnalyzer/performanceAnalyzer.js
@@ -2,7 +2,7 @@
 const _ = require('lodash');
 const moment = require('moment');
 
-const stats = require('../../core/stats');
+const statslite = require('stats-lite');
 const util = require('../../core/util');
 const ENV = util.gekkoEnv();
 
@@ -30,9 +30,10 @@ const PerformanceAnalyzer = function() {
 
   this.trades = 0;
 
-  this.sharpe = 0;
-
+  this.exposure = 0;
+  
   this.roundTrips = [];
+  this.losses = [];
   this.roundTrip = {
     entry: false,
     exit: false
@@ -144,14 +145,12 @@ PerformanceAnalyzer.prototype.handleCompletedRoundtrip = function() {
 
   this.deferredEmit('roundtrip', roundtrip);
 
-  // we need a cache for sharpe
-
-  // every time we have a new roundtrip
-  // update the cached sharpe ratio
-  this.sharpe = stats.sharpe(
-    this.roundTrips.map(r => r.profit),
-    perfConfig.riskFreeReturn
-  );
+  // update cached exposure
+  this.exposure = this.exposure + Date.parse(this.roundTrip.exit.date) - Date.parse(this.roundTrip.entry.date);
+  // track losses separately for downside report
+  if (roundtrip.exitBalance < roundtrip.entryBalance)
+    this.losses.push(roundtrip);
+  
 }
 
 PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
@@ -162,6 +161,15 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
     this.dates.end.diff(this.dates.start)
   );
   const relativeProfit = this.balance / this.start.balance * 100 - 100;
+  
+  const percentExposure = this.exposure / (Date.parse(this.dates.end) - Date.parse(this.dates.start));
+
+  const sharpe = (relativeYearlyProfit - perfConfig.riskFreeReturn) 
+    / statslite.stdev(this.roundTrips.map(r => r.profit)) 
+    / Math.sqrt(this.trades / (this.trades - 2));
+  
+  const downside = statslite.percentile(this.losses.map(r => r.profit), 0.25)
+    / Math.sqrt(this.trades / (this.trades - 2));
 
   const report = {
     startTime: this.dates.start.utc().format('YYYY-MM-DD HH:mm:ss'),
@@ -180,7 +188,9 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
     endPrice: this.endPrice,
     trades: this.trades,
     startBalance: this.start.balance,
-    sharpe: this.sharpe
+    exposure: percentExposure,
+    sharpe,
+    downside
   }
 
   report.alpha = report.profit - report.market;

--- a/plugins/performanceAnalyzer/performanceAnalyzer.js
+++ b/plugins/performanceAnalyzer/performanceAnalyzer.js
@@ -169,7 +169,7 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
     / Math.sqrt(this.trades / (this.trades - 2));
   
   const downside = statslite.percentile(this.losses.map(r => r.profit), 0.25)
-    / Math.sqrt(this.trades / (this.trades - 2));
+    * Math.sqrt(this.trades / (this.trades - 2));
 
   const report = {
     startTime: this.dates.start.utc().format('YYYY-MM-DD HH:mm:ss'),


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix: Sharpe ratio calculated according to the standard meaning.

Features: 
 - Added total exposure as a percentage to backtest report
 - Added expected downside (as Bessel-corrected downside quartile) to backtest report

* **What is the current behavior?** (You can also link to an open issue here)

Incorrect Sharpe: https://github.com/askmike/gekko/issues/2064

* **What is the new behavior (if this is a feature change)?**

More better backtest stats! :)

* **Other information**:
