### PR TITLE
Remove docker restart always

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 services:
   gekko:
-    restart: always
     build: ./
     volumes:
       - ./volumes/gekko/history:/usr/src/app/history


### PR DESCRIPTION
Remove `restart: always` from docker-compose.yml ? It made the project "up" automatically every time docker start and it's a bit anoying as it takes a port used by other project.