### PR TITLE
[WIP] enhance postgres stability

### DIFF
--- a/plugins/postgresql/handle.js
+++ b/plugins/postgresql/handle.js
@@ -2,41 +2,41 @@ const _ = require('lodash');
 const fs = require('fs');
 const pg = require('pg');
 
-var util = require('../../core/util.js');
-var config = util.getConfig();
-var dirs = util.dirs();
+const util = require('../../core/util.js');
+const config = util.getConfig();
+const dirs = util.dirs();
 
-var log = require(util.dirs().core + 'log');
-var postgresUtil = require('./util');
+const log = require(util.dirs().core + 'log');
+const postgresUtil = require('./util');
 
-var adapter = config.postgresql;
+const adapter = config.postgresql;
 
 // verify the correct dependencies are installed
-var pluginHelper = require(dirs.core + 'pluginUtil');
-var pluginMock = {
+const pluginHelper = require(dirs.core + 'pluginUtil');
+const pluginMock = {
   slug: 'postgresql adapter',
   dependencies: config.postgresql.dependencies
 };
 
-var cannotLoad = pluginHelper.cannotLoad(pluginMock);
+const cannotLoad = pluginHelper.cannotLoad(pluginMock);
 if(cannotLoad){
   util.die(cannotLoad);
 }
 
-var plugins = require(util.dirs().gekko + 'plugins');
+const plugins = require(util.dirs().gekko + 'plugins');
 
-var version = adapter.version;
+const version = adapter.version;
 
-var dbName = postgresUtil.database();
+const dbName = postgresUtil.database();
 
-var mode = util.gekkoMode();
+const mode = util.gekkoMode();
 
-var connectionString = config.postgresql.connectionString;
+const connectionString = config.postgresql.connectionString;
 
-var checkClient = new pg.Pool({
+const checkClient = new pg.Pool({
   connectionString: connectionString+'/postgres',
 });
-var pool = new pg.Pool({
+const pool = new pg.Pool({
   connectionString: connectionString+'/'+dbName,
 });
 

--- a/plugins/postgresql/handle.js
+++ b/plugins/postgresql/handle.js
@@ -44,6 +44,10 @@ const pool = new pg.Pool({
 // postgres database first. Your postgres
 // user will need appropriate rights.
 checkClient.connect((err, client, done) => {
+  if(err) {
+    util.die(err);
+  }
+
   log.debug("Check database exists: " + dbName);
   client.query("select count(*) from pg_catalog.pg_database where datname = $1", [dbName],
     (err, res) => {

--- a/plugins/postgresql/handle.js
+++ b/plugins/postgresql/handle.js
@@ -15,16 +15,14 @@ const pluginHelper = require(dirs.core + 'pluginUtil');
 const pluginMock = {
   slug: 'postgresql adapter',
   dependencies: config.postgresql.dependencies
-};
+}
 
 const cannotLoad = pluginHelper.cannotLoad(pluginMock);
-if(cannotLoad){
+if(cannotLoad) {
   util.die(cannotLoad);
 }
 
 const pg = require('pg');
-
-const plugins = require(util.dirs().gekko + 'plugins');
 
 const version = adapter.version;
 
@@ -35,59 +33,58 @@ const mode = util.gekkoMode();
 const connectionString = config.postgresql.connectionString;
 
 const checkClient = new pg.Pool({
-  connectionString: connectionString+'/postgres',
+  connectionString: connectionString + '/postgres',
 });
 const pool = new pg.Pool({
-  connectionString: connectionString+'/'+dbName,
+  connectionString: connectionString + '/' + dbName,
 });
 
-/* Postgres does not have 'create database if not exists' so we need to check if the db exists first.
-This requires connecting to the default postgres database first. Your postgres user will need appropriate rights. */
-//checkClient.connect(function(err){
-  //if(err){
-    //util.die(err);
-  //}
-checkClient.connect((err, client, done) => {  
-  log.debug("Check database exists: "+dbName);
+// We need to check if the db exists first.
+// This requires connecting to the default
+// postgres database first. Your postgres
+// user will need appropriate rights.
+checkClient.connect((err, client, done) => {
+  log.debug("Check database exists: " + dbName);
   const query = client.query("select count(*) from pg_catalog.pg_database where datname = $1",[dbName], 
     (err, res) => {
       if(err) {
-        done();
         util.die(err);
       }
-      if(res.rows[0].count == 0) { //database does not exist
-        log.debug("Database "+dbName+" does not exist");
-        if(mode === 'realtime') { //create database if not found
-          log.debug("Creating database "+dbName);
-          client.query("CREATE DATABASE "+dbName,function(err) {
-            done();
-            if(err){
-              done();
-              util.die(err);
-            } else {
-                log.debug("Postgres connection pool is ready, db "+dbName);
-                upsertTables();
-            }
-          });
-        }else if(mode === 'backtest') {
-          done();
-          util.die(`History does not exist for exchange ${config.watch.exchange}.`);
-        }else{
-          done();
-          util.die(`Start gekko first in realtime mode to create tables. You are currently in the '${mode}' mode.`);
-        }
-      }else{ //database exists
-        done();
-        log.debug("Database exists: "+dbName);
-        log.debug("Postgres connection pool is ready, db "+dbName);
-        upsertTables();
-      }  
+
+      if(res.rows[0].count !== 0) {
+        // database exists
+        log.debug("Database exists: " + dbName);
+        log.debug("Postgres connection pool is ready, db " + dbName);
+        upsertTables(done);
+        return;
+      }
+
+      // database dot NOT exist
+
+      if(mode === 'backtest') {
+        // no point in trying to backtest with
+        // non existing data.
+        util.die(`History does not exist for exchange ${config.watch.exchange}.`);
+      }
+
+      createDatabase(done);
     });
 });
 
 
-function upsertTables() {
-  var upsertQuery = 
+const createDatabase = next => {
+  client.query("CREATE DATABASE " + dbName, err => {
+    if(err) {
+      util.die(err);
+    }
+
+    log.debug("Postgres connection pool is ready, db " + dbName);
+    upsertTables(next);
+  });
+}
+
+const upsertTables = next => {
+  const upsertQuery =
     `CREATE TABLE IF NOT EXISTS
     ${postgresUtil.table('candles')} (
       id BIGSERIAL PRIMARY KEY,
@@ -102,9 +99,12 @@ function upsertTables() {
     );`;
 
 
-  pool.connect((err,client,done) => {
+  pool.connect((err, client, done) => {
+    if(err) {
+      util.die(err);
+    }
     client.query(upsertQuery, (err) => {
-      done();
+      next();
     });
   });
 }

--- a/plugins/postgresql/handle.js
+++ b/plugins/postgresql/handle.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const fs = require('fs');
-const pg = require('pg');
 
 const util = require('../../core/util.js');
 const config = util.getConfig();
@@ -22,6 +21,8 @@ const cannotLoad = pluginHelper.cannotLoad(pluginMock);
 if(cannotLoad){
   util.die(cannotLoad);
 }
+
+const pg = require('pg');
 
 const plugins = require(util.dirs().gekko + 'plugins');
 

--- a/sample-config.js
+++ b/sample-config.js
@@ -421,7 +421,7 @@ config.postgresql = {
   schema: 'public',
   dependencies: [{
     module: 'pg',
-    version: '6.1.0'
+    version: '7.4.3'
   }]
 }
 

--- a/web/routes/baseConfig.js
+++ b/web/routes/baseConfig.js
@@ -62,7 +62,7 @@ config.postgresql = {
   schema: 'public',
   dependencies: [{
     module: 'pg',
-    version: '6.1.0'
+    version: '7.4.3'
   }]
 }
 


### PR DESCRIPTION
ping @mark-sch, tiny fixes:

- make gekko first checks if PG is there before we load it.
- never call `done()` multiple times.
- make code more inline with the rest of the codebase (`const`, use "early exit" instead of nested ifs)
- update pg to 7.4.3 (mostly since 6.1.0 was complaining about a security attack vector)
- catch errors after all postgresql calls (the first one for checkClient was important since auth errors for example will fail silently and result in Gekko tripping over an undefined client object).
- will also create tables when gekko is run in importing mode.