### PR TITLE
Hotfix make sure bitfinex importer fetches all trades

### DIFF
--- a/exchange/wrappers/bitfinex.js
+++ b/exchange/wrappers/bitfinex.js
@@ -42,7 +42,6 @@ const recoverableErrors = [
   '443',
   '504',
   '503',
-  '500',
   '502',
   'Empty response',
   'Nonce is too small'

--- a/importers/exchanges/bitfinex.js
+++ b/importers/exchanges/bitfinex.js
@@ -76,7 +76,10 @@ var fetch = () => {
   if (lastTimestamp) {
     // We need to slow this down to prevent hitting the rate limits
     setTimeout(() => {
-      fetcher.getTrades(lastTimestamp, handleFetch);
+
+      // make sure we fetch with overlap from last batch
+      const since = lastTimestamp - 1000;
+      fetcher.getTrades(since, handleFetch);
     }, 2500);
   } else {
     lastTimestamp = from.valueOf();

--- a/importers/exchanges/bitfinex.js
+++ b/importers/exchanges/bitfinex.js
@@ -22,7 +22,7 @@ Fetcher.prototype.getTrades = function(upto, callback, descending) {
           tid: trade.ID,
           date: moment(trade.MTS).format('X'),
           price: +trade.PRICE,
-          amount: +trade.AMOUNT,
+          amount: +Math.abs(trade.AMOUNT),
         };
       });
     }
@@ -82,6 +82,7 @@ var fetch = () => {
     lastTimestamp = from.valueOf();
     batch_start = moment(from);
     batch_end = moment(from).add(stride, 'h');
+
     fetcher.getTrades(batch_end, handleFetch);
   }
 };


### PR DESCRIPTION
Should fix the issues described in #2307.

NOTE: while it currently already is an improvement (stores fatter candles with more trades) I am still seeing discrepancies with running this VS running a live trader on bitfinex.

I need to dig deeper, possible reasons:

- live trader is filtering valid trades
- importer uses BFX V2 API, live trader uses V1, maybe different results?