### PR TITLE
fix plugin event wire warning

### DIFF
--- a/core/pipeline.js
+++ b/core/pipeline.js
@@ -88,6 +88,8 @@ var pipeline = (settings) => {
     _.each(
       pluginSubscriptions.filter(s => _.isArray(s.emitter)),
       subscription => {
+        // cache full list
+        subscription.emitters = subscription.emitter;
         var singleEventEmitters = subscription.emitter
           .filter(
             s => _.size(plugins.filter(p => p.meta.slug === s))
@@ -110,18 +112,28 @@ var pipeline = (settings) => {
       _.each(pluginSubscriptions, function(sub) {
 
         if(plugin[sub.handler]) {
-
           // if a plugin wants to listen
           // to something disabled
           if(!emitters[sub.emitter]) {
             if(!plugin.meta.greedy) {
-              log.warn([
+
+              let emitterMessage;
+              if(sub.emitters) {
+                emitterMessage = 'all of the emitting plugins [ ';
+                emitterMessage += sub.emitters.join(', ');
+                emitterMessage += ' ] are disabled.';
+              } else {
+                emitterMessage += 'the emitting plugin (' + sub.emitter;
+                emitterMessage += ')is disabled.'
+              }
+
+              log.error([
                 plugin.meta.name,
-                'wanted to listen to the',
-                sub.emitter + ',',
-                'however the',
-                sub.emitter,
-                'is disabled.'
+                'wanted to listen to event',
+                sub.event + ',',
+                'however',
+                emitterMessage,
+                plugin.meta.name + ' might malfunction because of it.'
               ].join(' '));
             }
             return;

--- a/plugins.js
+++ b/plugins.js
@@ -200,7 +200,8 @@ var plugins = [
     description: 'Logs all gekko events.',
     slug: 'eventLogger',
     async: false,
-    modes: ['realtime', 'backtest']
+    modes: ['realtime', 'backtest'],
+    greedy: true
   },
   {
     name: 'Backtest result export',


### PR DESCRIPTION
CLI users are responsible for enabling a number of plugins so Gekko does what they want Gekko to do. Whenever a plugin a plugin is enabled that is supposed to consume events coming from a plugin that is NOT enabled Gekko will warn users. However this warning was broken for events that can originate from multiple plugins (for example the performanceAnalyzer needs to consume trade events to calculate profit - this can either be the paper trader OR the real trader).

This is currently broken like so:

    2018-07-26 10:21:17 (WARN): Event logger wanted to listen to the undefined, however the  is disabled.

This PR fixes that into:

    2018-07-26 10:35:50 (ERROR):  Trading Advisor wanted to listen to event tradeCompleted, however all of the emitting plugins [ trader, paperTrader ] are disabled. Trading Advisor might malfunction because of it.