### PR TITLE
make sure we pass on exchange error

### DIFF
--- a/core/tools/dataStitcher.js
+++ b/core/tools/dataStitcher.js
@@ -197,6 +197,10 @@ Stitcher.prototype.checkExchangeTrades = function(since, next) {
 
   var watcher = new DataProvider(exchangeConfig);
   watcher.getTrades(since, function(e, d) {
+    if(e) {
+      util.die(e.message);
+    }
+
     if(_.isEmpty(d))
       return util.die(
         `Gekko tried to retrieve data since ${since.format('YYYY-MM-DD HH:mm:ss')}, however


### PR DESCRIPTION
The current data stitcher doesn't check error from the exchange. In some scenarios this is the first API call to the exchange, meaning gekko won't stop with any meaningful error. Example:

![2018-07-28 15 35 17](https://user-images.githubusercontent.com/969743/43354298-21ad4e94-927c-11e8-9a34-f42e12c1c024.jpg)

This PR fixes that :)