### PR TITLE
[WIP] handle binance insufficient funds because of partial fills

### DIFF
--- a/exchange/gekkoBroker.js
+++ b/exchange/gekkoBroker.js
@@ -136,7 +136,7 @@ class Broker {
 
     const order = new orders[type]({
       api: this.api,
-      market: this.marketConfig,
+      marketConfig: this.marketConfig,
       capabilities: this.capabilities
     });
 

--- a/exchange/gekkoBroker.js
+++ b/exchange/gekkoBroker.js
@@ -134,14 +134,17 @@ class Broker {
     if(!orders[type])
       throw new Error('Unknown order type');
 
-    const order = new orders[type](this.api);
+    const order = new orders[type]({
+      api: this.api,
+      market: this.marketConfig,
+      capabilities: this.capabilities
+    });
 
     // todo: figure out a smarter generic way
     this.syncPrivateData(() => {
       order.setData({
         balances: this.portfolio.balances,
         ticker: this.ticker,
-        market: this.marketConfig
       });
 
       order.create(side, amount, parameters);

--- a/exchange/orders/order.js
+++ b/exchange/orders/order.js
@@ -26,7 +26,7 @@ class BaseOrder extends EventEmitter {
 
   submit({side, amount, price, alreadyFilled}) {
     const check = isValidOrder({
-      market: this.data.market,
+      market: this.market,
       api: this.api,
       amount,
       price

--- a/exchange/orders/sticky.js
+++ b/exchange/orders/sticky.js
@@ -24,7 +24,7 @@ class StickyOrder extends BaseOrder {
   constructor({api, marketConfig, capabilities}) {
     super(api);
 
-    this.marketConfig = marketConfig;
+    this.market = marketConfig;
     this.capabilities = capabilities;
 
     // global async lock
@@ -450,7 +450,7 @@ class StickyOrder extends BaseOrder {
 
     this.amount = this.roundAmount(amount - this.calculateFilled());
 
-    if(this.amount < this.data.market.minimalOrder.amount) {
+    if(this.amount < this.market.minimalOrder.amount) {
       if(this.calculateFilled()) {
         // we already filled enough of the order!
         this.filled();

--- a/exchange/orders/sticky.js
+++ b/exchange/orders/sticky.js
@@ -142,8 +142,6 @@ class StickyOrder extends BaseOrder {
       return false;
     }
 
-    console.log(new Date, '[GB/insufficientFunds] on limitedCancelConfirmation market:');
-
     const id = this.id;
 
     setTimeout(
@@ -156,12 +154,10 @@ class StickyOrder extends BaseOrder {
           const amount = res.amount;
 
           if(this.orders[id].filled === amount) {
-            console.log(new Date, '[GB/insufficientFunds] found no partial fill');
             // handle original error
             return this.handleError(err);
           }
 
-          console.log(new Date, '[GB/insufficientFunds] found a partial fill of', amount - this.orders[id].filled);
           this.orders[id].filled = amount;
           this.emit('fill', this.calculateFilled());
           if(this.calculateFilled() >= this.amount) {

--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -126,7 +126,7 @@ Trader.prototype.handleResponse = function(funcName, callback) {
 
         // temp debug
         if(this.oldOrder) {
-          this.getOrder(oldOrder, (err, res) => {
+          this.getOrder(this.oldOrder, (err, res) => {
             console.log('partial fill on old order?', {err, res});
           });
         }

--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -64,6 +64,8 @@ const Trader = function(config) {
     this.fee = 0.1;
     // Set the proper fee asap.
     this.getFee(_.noop);
+
+    this.oldOrder = false;
   }
 };
 
@@ -119,8 +121,15 @@ Trader.prototype.handleResponse = function(funcName, callback) {
 
       if(funcName === 'addOrder' && error.message.includes('Account has insufficient balance')) {
         // https://github.com/askmike/gekko/issues/2405
-        console.log('Binance said: "Account has insufficient balance", retrying up to 3 times..');
-        error.retry = 3;
+        console.log('Binance said: "Account has insufficient balance", retrying once..');
+        error.retry = 1;
+
+        // temp debug
+        if(this.oldOrder) {
+          this.getOrder(oldOrder, (err, res) => {
+            console.log('partial fill on old order?', {err, res});
+          });
+        }
       }
 
       return callback(error);
@@ -466,6 +475,9 @@ Trader.prototype.checkOrder = function(order, callback) {
 Trader.prototype.cancelOrder = function(order, callback) {
 
   const cancel = (err, data) => {
+
+    this.oldOrder = order;
+
     if(err) {
       return callback(err);
     }

--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -307,7 +307,6 @@ Trader.prototype.isValidPrice = function(price) {
 }
 
 Trader.prototype.isValidLot = function(price, amount) {
-  console.log('isValidLot', this.market.minimalOrder.order, amount * price >= this.market.minimalOrder.order)
   return amount * price >= this.market.minimalOrder.order;
 }
 

--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -117,6 +117,12 @@ Trader.prototype.handleResponse = function(funcName, callback) {
         return callback(false, {filled: true});
       }
 
+      if(funcName === 'addOrder' && error.message.includes('Account has insufficient balance')) {
+        // https://github.com/askmike/gekko/issues/2405
+        console.log('Binance said: "Account has insufficient balance", retrying up to 3 times..');
+        error.retry = 3;
+      }
+
       return callback(error);
     }
 

--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -120,16 +120,7 @@ Trader.prototype.handleResponse = function(funcName, callback) {
       }
 
       if(funcName === 'addOrder' && error.message.includes('Account has insufficient balance')) {
-        // https://github.com/askmike/gekko/issues/2405
-        console.log('Binance said: "Account has insufficient balance", retrying once..');
-        error.retry = 1;
-
-        // temp debug
-        if(this.oldOrder) {
-          this.getOrder(this.oldOrder, (err, res) => {
-            console.log('partial fill on old order?', {err, res});
-          });
-        }
+        error.type = 'insufficientFunds';
       }
 
       return callback(error);
@@ -479,6 +470,8 @@ Trader.prototype.cancelOrder = function(order, callback) {
     this.oldOrder = order;
 
     if(err) {
+      if(err.message.contains(''))
+
       return callback(err);
     }
 
@@ -510,7 +503,8 @@ Trader.getCapabilities = function() {
     providesFullHistory: true,
     tid: 'tid',
     tradable: true,
-    gekkoBroker: 0.6
+    gekkoBroker: 0.6,
+    limitedCancelConfirmation: true
   };
 };
 

--- a/plugins/trader/trader.js
+++ b/plugins/trader/trader.js
@@ -246,7 +246,7 @@ Trader.prototype.createOrder = function(side, amount, advice, id) {
 
   this.order = this.broker.createOrder(type, side, amount);
 
-  this.order.on('filled', f => log.info('[ORDER] partial', side, ' fill, total filled:', f));
+  this.order.on('fill', f => log.info('[ORDER] partial', side, 'fill, total filled:', f));
   this.order.on('statusChange', s => log.debug('[ORDER] statusChange:', s));
 
   this.order.on('error', e => {


### PR DESCRIPTION
Binance does not provide partial fill information on cancel, as such Gekko might not be aware a partial fill happened between the last order check and the cancel. See #2405 and #2308.

This workaround catches situations where this occurrence results in a "insufficient funds" error by catching it and manually the checking the order which was last cancelled.

This branch needs more testing, please help out so we can get this in Gekko quicker! If you are not sure how read this: https://gekko.wizb.it/docs/installation/updating_gekko.html#Updating-the-develop-branch and replace `git checkout develop` with `git checkout hotfix/binance-insufficient-funds`