### PR TITLE
[GB] check installed deps & log user friendly error, fix #2455

### DIFF
--- a/core/tools/dataStitcher.js
+++ b/core/tools/dataStitcher.js
@@ -18,6 +18,7 @@ Stitcher.prototype.ago = function(ts) {
 }
 
 Stitcher.prototype.verifyExchange = function() {
+  require(dirs.gekko + 'exchange/dependencyCheck');
   const exchangeChecker = require(dirs.gekko + 'exchange/exchangeChecker');
   const slug = config.watch.exchange.toLowerCase();
   let exchange;

--- a/exchange/dependencyCheck.js
+++ b/exchange/dependencyCheck.js
@@ -1,0 +1,23 @@
+const deps = require('./package.json').dependencies;
+
+const missing = [];
+
+Object.keys(deps).forEach(dep => {
+  try {
+    require(dep);
+  } catch(e) {
+    if(e.code === 'MODULE_NOT_FOUND') {
+      missing.push(dep);
+    }
+  }
+});
+
+if(missing.length) {
+  console.error(
+    '\nThe following Gekko Broker dependencies are not installed: [',
+    missing.join(', '),
+    '].\n\nYou need to install them first, read here how:',
+    'https://gekko.wizb.it/docs/installation/installing_gekko.html#Installing-Gekko-39-s-dependencies\n'
+  );
+  process.exit(1);
+}

--- a/plugins/trader/trader.js
+++ b/plugins/trader/trader.js
@@ -7,6 +7,8 @@ const moment = require('moment');
 const log = require(dirs.core + 'log');
 const Broker = require(dirs.gekko + '/exchange/gekkoBroker');
 
+require(dirs.gekko + '/exchange/dependencyCheck');
+
 const Trader = function(next) {
 
   _.bindAll(this);


### PR DESCRIPTION
If a user has not installed Gekko Broker, Gekko will now log a more user friendly error like:

    ➜  gekko git:(hotfix/gb-check-installed-deps) ✗ node gekko -c cer.js

        ______   ________  __    __  __    __   ______
       /      \ /        |/  |  /  |/  |  /  | /      \
      /$$$$$$  |$$$$$$$$/ $$ | /$$/ $$ | /$$/ /$$$$$$  |
      $$ | _$$/ $$ |__    $$ |/$$/  $$ |/$$/  $$ |  $$ |
      $$ |/    |$$    |   $$  $$<   $$  $$<   $$ |  $$ |
      $$ |$$$$ |$$$$$/    $$$$$  \  $$$$$  \  $$ |  $$ |
      $$ \__$$ |$$ |_____ $$ |$$  \ $$ |$$  \ $$ \__$$ |
      $$    $$/ $$       |$$ | $$  |$$ | $$  |$$    $$/ 
       $$$$$$/  $$$$$$$$/ $$/   $$/ $$/   $$/  $$$$$$/

      Gekko v0.6.5
      I'm gonna make you rich, Bud Fox. 


    2018-08-20 15:26:46 (INFO): Setting up Gekko in realtime mode
    2018-08-20 15:26:46 (INFO): 
    2018-08-20 15:26:46 (INFO): Setting up:
    2018-08-20 15:26:46 (INFO):    Trading Advisor
    2018-08-20 15:26:46 (INFO):    Calculate trading advice
    2018-08-20 15:26:46 (INFO):    Using the strategy: DEBUG_single-advice

    The following Gekko Broker dependencies are not installed: [ binance, bitx, coinfalcon, gdax, kraken-api, gekko-broker-poloniex, gekko-bittrex ].

    You need to install them first, read here how: https://gekko.wizb.it/docs/installation/installing_gekko.html#Installing-Gekko-39-s-dependencies

Or with the UI (in the terminal)

      <-- GET /api/configPart/paperTrader
      --> GET /api/configPart/paperTrader 200 15ms 132b
      <-- POST /api/startGekko

    The following Gekko Broker dependencies are not installed: [ binance, bitx, coinfalcon, gdax, kraken-api, gekko-broker-poloniex, gekko-bittrex ].

    You need to install them first, read here how: https://gekko.wizb.it/docs/installation/installing_gekko.html#Installing-Gekko-39-s-dependencies

Showing them in the UI is too much work, I'll make sure that happens in the next UI I'm building.