### PR TITLE
bugfix #2457

### DIFF
--- a/core/workers/loadCandles/child.js
+++ b/core/workers/loadCandles/child.js
@@ -22,3 +22,7 @@ process.on('message', (m) => {
   if(m.what === 'start')
     start(m.config, m.candleSize, m.daterange);
 });
+
+process.on('disconnect', function() {
+  process.exit(0);
+})

--- a/core/workers/loadCandles/parent.js
+++ b/core/workers/loadCandles/parent.js
@@ -56,7 +56,7 @@ module.exports = (config, callback) => {
 
     // else we are done and have candles!
     done(null, m);
-    child.kill('SIGINT');
+    this.disconnect();
   });
 
   child.on('exit', code => {


### PR DESCRIPTION
Sometimes child.kill() failes. Better disconnect the parent and let the
child exit itself.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix #2457


* **What is the current behavior?** (You can also link to an open issue here)
Sometimes child.kill() failes.


* **What is the new behavior (if this is a feature change)?**
child get killed


* **Other information**:
