### PR TITLE
Feature strategy #762

### DIFF
--- a/config/strategies/MACD_multiple_timeframes.toml
+++ b/config/strategies/MACD_multiple_timeframes.toml
@@ -1,0 +1,8 @@
+short = 10
+long = 21
+signal = 9
+
+[thresholds]
+down = -0.025
+up = 0.025
+persistence = 1

--- a/core/workers/loadCandles/child.js
+++ b/core/workers/loadCandles/child.js
@@ -22,3 +22,7 @@ process.on('message', (m) => {
   if(m.what === 'start')
     start(m.config, m.candleSize, m.daterange);
 });
+
+process.on('disconnect', function() {
+  process.exit(0);
+})

--- a/core/workers/loadCandles/parent.js
+++ b/core/workers/loadCandles/parent.js
@@ -56,7 +56,7 @@ module.exports = (config, callback) => {
 
     // else we are done and have candles!
     done(null, m);
-    child.kill('SIGINT');
+    this.disconnect();
   });
 
   child.on('exit', code => {

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -66,6 +66,9 @@ var Base = function(settings) {
   if(!this.onTrade)
     this.onTrade = function() {};
 
+  if(!this.updateOneMin) //get OneMinCandles!
+    this.updateOneMin = function() {};
+
   // let's run the implemented starting point
   this.init();
 

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -86,6 +86,9 @@ Actor.prototype.setupStrategy = function() {
 // HANDLERS
 // process the 1m candles
 Actor.prototype.processCandle = function(candle, done) {
+  // notify strategy about one min
+  this.strategy.updateOneMin(candle);
+
   this.candle = candle;
   const completedBatch = this.batcher.write([candle]);
   if(completedBatch) {

--- a/strategies/MACD_multiple_timeframes.js
+++ b/strategies/MACD_multiple_timeframes.js
@@ -1,0 +1,140 @@
+/*
+
+  MACD - DJM 31/12/2013
+
+  (updated a couple of times since, check git history)
+
+ */
+
+// helpers
+var _ = require('lodash');
+var log = require('../core/log.js');
+
+// let's create our own method
+var method = {};
+
+// prepare everything our method needs
+method.init = function() {
+  // keep state about the current trend
+  // here, on every new candle we use this
+  // state object to check if we need to
+  // report it.
+  this.trend = {
+    direction: 'none',
+    duration: 0,
+    persisted: false,
+    adviced: false
+  };
+
+  // how many candles do we need as a base
+  // before we can start giving advice?
+  this.requiredHistory = this.tradingAdvisor.historySize;
+
+  // define the indicators we need
+  this.addIndicator('macd', 'MACD', this.settings);
+}
+
+// what happens on every new candle?
+method.update = function(candle) {
+  // nothing!
+}
+
+// for debugging purposes: log the last calculated
+// EMAs and diff.
+method.log = function() {
+  var digits = 8;
+  var macd = this.indicators.macd;
+
+  var diff = macd.diff;
+  var signal = macd.signal.result;
+
+  log.debug('calculated MACD properties for candle:');
+  log.debug('\t', 'short:', macd.short.result.toFixed(digits));
+  log.debug('\t', 'long:', macd.long.result.toFixed(digits));
+  log.debug('\t', 'macd:', diff.toFixed(digits));
+  log.debug('\t', 'signal:', signal.toFixed(digits));
+  log.debug('\t', 'macdiff:', macd.result.toFixed(digits));
+}
+
+method.check = function() {
+  var macddiff = this.indicators.macd.result;
+
+  if(macddiff > this.settings.thresholds.up) {
+
+    // new trend detected
+    if(this.trend.direction !== 'up')
+      // reset the state for the new trend
+      this.trend = {
+        duration: 0,
+        persisted: false,
+        direction: 'up',
+        adviced: false
+      };
+
+    this.trend.duration++;
+
+    log.debug('In uptrend since', this.trend.duration, 'candle(s)');
+
+    if(this.trend.duration >= this.settings.thresholds.persistence)
+      this.trend.persisted = true;
+
+    if(this.trend.persisted && !this.trend.adviced) {
+      this.trend.adviced = true;
+      this.advice('long');
+    } else
+      this.advice();
+
+  } else if(macddiff < this.settings.thresholds.down) {
+
+    // new trend detected
+    if(this.trend.direction !== 'down')
+      // reset the state for the new trend
+      this.trend = {
+        duration: 0,
+        persisted: false,
+        direction: 'down',
+        adviced: false
+      };
+
+    this.trend.duration++;
+
+    log.debug('In downtrend since', this.trend.duration, 'candle(s)');
+
+    if(this.trend.duration >= this.settings.thresholds.persistence)
+      this.trend.persisted = true;
+
+    if(this.trend.persisted && !this.trend.adviced) {
+      this.trend.adviced = true;
+      this.advice('short');
+    } else
+      this.advice();
+
+  } else {
+
+    log.debug('In no trend');
+
+    // we're not in an up nor in a downtrend
+    // but for now we ignore sideways trends
+    //
+    // read more @link:
+    //
+    // https://github.com/askmike/gekko/issues/171
+
+    // this.trend = {
+    //   direction: 'none',
+    //   duration: 0,
+    //   persisted: false,
+    //   adviced: false
+    // };
+
+    this.advice();
+  }
+}
+
+/***
+ * here we get one min candles
+ */
+method.updateOneMin = function(candle) {
+  log.debug(' close: '+candle.close);
+}
+module.exports = method;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature #762: pass one minute candle to strategy for stoploss or making with CandleBatcher other candles.

I use in my strategy various candles and the easy way to implement it it to pass one min to the strategy. There is also default implementation in baseTradingStrategy if the strategy don't implemnt updateOneMin.

* **What is the current behavior?** (You can also link to an open issue here)
Now the strategy get only fixed candle which we can specify at the beginning. But for stoploss and other complex strategies we need different candle sizes.

* **What is the new behavior (if this is a feature change)?**
There is a default implementation of updateOneMin in baseTradingStrategy. In the strategy we can now define updateOneMin(candle) and get the small candles.


* **Other information**:
