### PR TITLE
Finish candleloader on empty data, fix #2457

### DIFF
--- a/core/tools/candleLoader.js
+++ b/core/tools/candleLoader.js
@@ -78,7 +78,7 @@ const handleCandles = (err, data) => {
     util.die('Encountered an error..')
   }
 
-  if(_.size(data) && _.last(data).start >= toUnix)
+  if(_.size(data) && _.last(data).start >= toUnix || iterator.from.unix() >= toUnix)
     DONE = true;
 
   batcher.write(data);

--- a/core/workers/loadCandles/child.js
+++ b/core/workers/loadCandles/child.js
@@ -22,3 +22,7 @@ process.on('message', (m) => {
   if(m.what === 'start')
     start(m.config, m.candleSize, m.daterange);
 });
+
+process.on('disconnect', function() {
+  process.exit(0);
+})

--- a/core/workers/loadCandles/parent.js
+++ b/core/workers/loadCandles/parent.js
@@ -56,7 +56,7 @@ module.exports = (config, callback) => {
 
     // else we are done and have candles!
     done(null, m);
-    child.kill('SIGINT');
+    this.disconnect();
   });
 
   child.on('exit', code => {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix. 

* **What is the current behavior?** (You can also link to an open issue here)
Still getting sometimes node processes of candleLoader which never get killed. If reader data is empty than DONE never set to true and there is an infinite loop. 


* **What is the new behavior (if this is a feature change)?**
Now checking if iterator.from is > than "to" and ending the candleLaoder.


* **Other information**:
