### PR TITLE
make sure to flush the batcher, fix #2329

### DIFF
--- a/core/tools/dataStitcher.js
+++ b/core/tools/dataStitcher.js
@@ -223,6 +223,7 @@ Stitcher.prototype.seedLocalData = function(from, to, next) {
     });
 
     this.batcher.write(rows);
+    this.batcher.flush();
     this.reader.close();
     next();
 

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -92,14 +92,15 @@ Actor.prototype.processCandle = function(candle, done) {
     this.next = done;
   } else {
     done();
-    this.next = _.noop;
+    this.next = false;
   }
   this.batcher.flush();
 }
 
 // propogate a custom sized candle to the trading strategy
 Actor.prototype.emitStratCandle = function(candle) {
-  this.strategy.tick(candle, this.next);
+  const next = this.next || _.noop;
+  this.strategy.tick(candle, next);
 }
 
 Actor.prototype.processTradeCompleted = function(trade) {


### PR DESCRIPTION
The datastitcher preloads local candle data (from DB) into your strategy. However the candleBatcher now requires flushing (since 0.6.x somewhere) - which the datasticher did not do. It causes the bug described in #2329.

While this is a serious issue effecting candles fed into strategies, I don't consider it that critical since problem scenarios crashed with the error from #2329 instead of running with dirty data.