### PR TITLE
[GB] make sure we always check pending actions

### DIFF
--- a/exchange/orders/sticky.js
+++ b/exchange/orders/sticky.js
@@ -207,21 +207,30 @@ class StickyOrder extends BaseOrder {
     this.status = states.OPEN;
     this.emitStatus();
 
+    this.scheduleNextCheck();
+  }
+
+  scheduleNextCheck() {
+
     // remove lock
     this.sticking = false;
 
     // check whether we had an action pending
-    if(this.cancelling)
+    if(this.cancelling) {
       return this.cancel();
+    }
 
-    if(this.movingLimit)
+    if(this.movingLimit) {
       return this.moveLimit();
+    }
 
-    if(this.movingAmount)
+    if(this.movingAmount) {
       return this.moveAmount();
+    }
 
     // register check
     this.timeout = setTimeout(this.checkOrder, this.checkInterval);
+
   }
 
   checkOrder() {
@@ -245,8 +254,7 @@ class StickyOrder extends BaseOrder {
         // if we are already at limit we dont care where the top is
         // note: might be string VS float
         if(this.price == this.limit) {
-          this.timeout = setTimeout(this.checkOrder, this.checkInterval);
-          this.sticking = false;
+          this.scheduleNextCheck();
           return;
         }
 
@@ -264,8 +272,7 @@ class StickyOrder extends BaseOrder {
             return this.move(this.calculatePrice(ticker));
           }
 
-          this.timeout = setTimeout(this.checkOrder, this.checkInterval);
-          this.sticking = false;
+          this.scheduleNextCheck();
         });
 
         return;
@@ -409,7 +416,7 @@ class StickyOrder extends BaseOrder {
       this.sticking = true;
       this.move(this.limit);
     } else {
-      this.timeout = setTimeout(this.checkOrder, this.checkInterval);
+      this.scheduleNextCheck();
     }
 
     return true;
@@ -492,6 +499,7 @@ class StickyOrder extends BaseOrder {
 
     this.completing = true;
     clearTimeout(this.timeout);
+
     this.api.cancelOrder(this.id, (err, filled, data) => {
       if(this.handleError(err)) {
         return;


### PR DESCRIPTION
The sticky order only checks pending actions (such as when the user requests a cancel but there is an API call inflight) after creating a new order, on stale markets this might take hours. This PR also checks the basic check loop (check ticker, check order).