### PR TITLE
Added possibility to use async init, update and check functions inside strategy development

### DIFF
--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -67,8 +67,8 @@ var Base = function(settings) {
   if(!this.onTrade)
     this.onTrade = function() {};
 
-  // let's run the implemented starting point
-  this.initBase();
+  if(!this.onCandle)
+    this.onCandle = function() {};
 
   if(!config.debug || !this.log)
     this.log = function() {};
@@ -84,15 +84,6 @@ var Base = function(settings) {
 // teach our base trading method events
 util.makeEventEmitter(Base);
 
-Base.prototype.initBase = async function() {
-  //strategy developers can implement their INIT function with or without async
-  if (Base.prototype['init'] instanceof AsyncFunction) {
-     await this.init();
-  }
-  else {
-     this.init();
-  }
-}
 
 Base.prototype.tick = function(candle, done) {
   this.age++;

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -4,6 +4,7 @@ const util = require('../../core/util');
 const config = util.getConfig();
 const dirs = util.dirs();
 const log = require(dirs.core + 'log');
+const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
 
 const ENV = util.gekkoEnv();
 const mode = util.gekkoMode();
@@ -67,7 +68,7 @@ var Base = function(settings) {
     this.onTrade = function() {};
 
   // let's run the implemented starting point
-  this.init();
+  this.initBase();
 
   if(!config.debug || !this.log)
     this.log = function() {};
@@ -82,6 +83,16 @@ var Base = function(settings) {
 
 // teach our base trading method events
 util.makeEventEmitter(Base);
+
+Base.prototype.initBase = async function() {
+  //strategy developers can implement their INIT function with or without async
+  if (Base.prototype['init'] instanceof AsyncFunction) {
+     await this.init();
+  }
+  else {
+     this.init();
+  }
+}
 
 Base.prototype.tick = function(candle, done) {
   this.age++;
@@ -127,10 +138,15 @@ Base.prototype.calculateSyncIndicators = function(candle, done) {
   return done();
 }
 
-Base.prototype.propogateTick = function(candle) {
+Base.prototype.propogateTick = async function(candle) {
   this.candle = candle;
-  this.update(candle);
 
+  //strategy developers can implement their UPDATE function with or without async 
+  if (Base.prototype['update'] instanceof AsyncFunction)
+     await this.update(candle);
+  else
+     this.update(candle);
+  
   this.processedTicks++;
   var isAllowedToCheck = this.requiredHistory <= this.age;
 
@@ -160,7 +176,12 @@ Base.prototype.propogateTick = function(candle) {
 
   if(this.completedWarmup) {
     this.log(candle);
-    this.check(candle);
+
+    //strategy developers can implement their CHECK function with or without async 
+    if (Base.prototype['check'] instanceof AsyncFunction)
+      await this.check(candle);
+    else
+      this.check(candle);
 
     if(
       this.asyncTick &&
@@ -202,14 +223,14 @@ Base.prototype.propogateTick = function(candle) {
 Base.prototype.processTrade = function(trade) {
   if(
     this._pendingTriggerAdvice &&
-    trade.action === 'sell' &&
-    this._pendingTriggerAdvice === trade.adviceId
+    trade.action === 'sell' //&&
+    //this._pendingTriggerAdvice === trade.adviceId
   ) {
     // This trade came from a trigger of the previous advice,
     // update stored direction
     this._currentDirection = 'short';
     this._pendingTriggerAdvice = null;
-  }
+  };
 
   this.onTrade(trade);
 }
@@ -248,6 +269,7 @@ Base.prototype.advice = function(newDirection) {
     }
 
     if(newDirection.direction === this._currentDirection) {
+      log.debug('Got advice to go', newDirection.direction, 'again - skip this double advice!');
       return;
     }
 
@@ -264,7 +286,7 @@ Base.prototype.advice = function(newDirection) {
 
         if(trigger.trailPercentage && !trigger.trailValue) {
           trigger.trailValue = trigger.trailPercentage / 100 * this.candle.close;
-          log.info('[StratRunner] Trailing stop trail value specified as percentage, setting to:', trigger.trailValue);
+          //log.info('[StratRunner] Trailing stop trail value specified as percentage, setting to:', trigger.trailValue);
         }
       }
     }

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -72,7 +72,13 @@ var Base = function(settings) {
 
   if(!config.debug || !this.log)
     this.log = function() {};
+}
 
+// teach our base trading method events
+util.makeEventEmitter(Base);
+
+
+Base.prototype.startRunner = function() {
   this.setup = true;
 
   if(_.size(this.asyncIndicatorRunner.talibIndicators) || _.size(this.asyncIndicatorRunner.tulipIndicators))
@@ -80,9 +86,6 @@ var Base = function(settings) {
   else
     delete this.asyncIndicatorRunner;
 }
-
-// teach our base trading method events
-util.makeEventEmitter(Base);
 
 
 Base.prototype.tick = function(candle, done) {

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -66,6 +66,7 @@ Actor.prototype.setupStrategy = async function(cb) {
   else {
     this.strategy.init();
   }
+  this.strategy.startRunner();
 
   this.strategy
     .on('advice', this.relayAdvice)

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -2,6 +2,7 @@ var util = require('../../core/util');
 var _ = require('lodash');
 var fs = require('fs');
 var toml = require('toml');
+const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
 
 var config = util.getConfig();
 var dirs = util.dirs();
@@ -20,23 +21,23 @@ var Actor = function(done) {
 
   this.strategyName = config.tradingAdvisor.method;
 
-  this.setupStrategy();
+  this.setupStrategy(function() {
+    var mode = util.gekkoMode();
 
-  var mode = util.gekkoMode();
-
-  // the stitcher will try to pump in historical data
-  // so that the strat can use this data as a "warmup period"
-  //
-  // the realtime "leech" market won't use the stitcher
-  if(mode === 'realtime' && !isLeecher) {
-    var Stitcher = require(dirs.tools + 'dataStitcher');
-    var stitcher = new Stitcher(this.batcher);
-    stitcher.prepareHistoricalData(done);
-  } else
-    done();
+    // the stitcher will try to pump in historical data
+    // so that the strat can use this data as a "warmup period"
+    //
+    // the realtime "leech" market won't use the stitcher
+    if(mode === 'realtime' && !isLeecher) {
+      var Stitcher = require(dirs.tools + 'dataStitcher');
+      var stitcher = new Stitcher(this.batcher);
+      stitcher.prepareHistoricalData(done);
+    } else
+      done();
+    });
 }
 
-Actor.prototype.setupStrategy = function() {
+Actor.prototype.setupStrategy = async function(cb) {
 
   if(!fs.existsSync(dirs.methods + this.strategyName + '.js'))
     util.die('Gekko can\'t find the strategy "' + this.strategyName + '"');
@@ -59,6 +60,13 @@ Actor.prototype.setupStrategy = function() {
   }
 
   this.strategy = new WrappedStrategy(stratSettings);
+  if (WrappedStrategy.prototype['init'] instanceof AsyncFunction) {
+    await this.strategy.init();
+  }
+  else {
+    this.strategy.init();
+  }
+
   this.strategy
     .on('advice', this.relayAdvice)
     .on(
@@ -81,12 +89,23 @@ Actor.prototype.setupStrategy = function() {
       this.deferredEmit('stratCandle', candle);
       this.emitStratCandle(candle);
     });
+
+  cb();
 }
 
 // HANDLERS
 // process the 1m candles
-Actor.prototype.processCandle = function(candle, done) {
+Actor.prototype.processCandle = async function(candle, done) {
   this.candle = candle;
+
+  //strategy developers can implement their ONCANDLE function with or without async
+  if (this.strategy.onCandle instanceof AsyncFunction) {
+    await this.strategy.onCandle(candle);
+  }
+  else {
+      this.strategy.onCandle(candle);
+  }
+
   const completedBatch = this.batcher.write([candle]);
   if(completedBatch) {
     this.next = done;

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -2,6 +2,7 @@ var util = require('../../core/util');
 var _ = require('lodash');
 var fs = require('fs');
 var toml = require('toml');
+const WrappedStrategy = require('./baseTradingMethod');
 const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
 
 var config = util.getConfig();
@@ -48,8 +49,6 @@ Actor.prototype.setupStrategy = async function(cb) {
 
   // bind all trading strategy specific functions
   // to the WrappedStrategy.
-  const WrappedStrategy = require('./baseTradingMethod');
-
   _.each(strategy, function(fn, name) {
     WrappedStrategy.prototype[name] = fn;
   });
@@ -100,7 +99,7 @@ Actor.prototype.processCandle = async function(candle, done) {
   this.candle = candle;
 
   //strategy developers can implement their ONCANDLE function with or without async
-  if (this.strategy.onCandle instanceof AsyncFunction) {
+  if (WrappedStrategy.prototype['onCandle'] instanceof AsyncFunction) {
     await this.strategy.onCandle(candle);
   }
   else {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
At this moment it is impossible to perform async operations inside the strategy development. In this case it might happen, that your strategy is still performing calculations on a candle while gekko is already looping for the next update and check function for the next candle => strategy and strategy function calls get out of sync.

See discussion here: https://github.com/askmike/gekko/issues/2525


* **What is the new behavior (if this is a feature change)?**
The extended baseTradingMethod allows now to use the init, update and check implementations the same way as before (backward compatibility) but also recognizes if a strategy developer declares his functions async. In this case the baseTradingMethod will await the strategy to complete first before continuing its excution.


* **Other information**:
The current and new baseTradingMethod has been tested with several log outputs to confirm the functionality

Current behaviour, using current code in baseTradingMethod.js:

this.update(candle)

Testing with extended console logs:
1 - before this.update(candle); true
OK, calling this.update(candle) ...
2 - inside strat update
3 - inside strat update
5 - after this.update(candle);
4 - inside strat update  <= this is the problem,
the baseTradingMethod.js continues executing 
despite strategy calculations are not completed yet

1 - before this.update(candle); true
OK, calling this.update(candle) ...
2 - inside strat update
3 - inside strat update
5 - after this.update(candle);
4 - inside strat update



Changed baseTradingMethod.js, using this code:

//strategy developers can implement their UPDATE function with or without async 
if (Base.prototype['update'] instanceof AsyncFunction)
   await this.update(candle);
else
   this.update(candle);

1 - before this.update(candle); true
OK, calling await this.update(candle) ...
2 - inside strat update
3 - inside strat update
4 - inside strat update
5 - after this.update(candle); <= code execution
is running in correct order

1 - before this.update(candle); true
OK, calling await this.update(candle) ...
2 - inside strat update
3 - inside strat update
4 - inside strat update
5 - after this.update(candle);