### PR TITLE
Added async Talib indicator

### DIFF
--- a/strategies/indicators/TalibAsync.js
+++ b/strategies/indicators/TalibAsync.js
@@ -1,0 +1,88 @@
+// ****************************************************************************
+// *** TalibSync.js                                                         ***
+// ****************************************************************************
+// * Purpose: Use a Talib indicator inside a strategy like any other native
+// * gekko indicator - in a synchronous way, by executing talib functionality
+// * with await/promise.
+// * This approach also exposes Talib functionality to multi timeframe
+// * strategies, with custom candle size batching, where asyncIndicatorRunner 
+// * is not available 
+// ****************************************************************************
+
+
+const util = require('../../core/util')
+const dirs = util.dirs();
+const gekkotalib = require(dirs.core + 'talib');
+const talib = require("talib");
+const log = require(dirs.core + 'log');
+
+
+var Indicator = function(config) {
+    this.config = config;
+    this.talibInput = [];
+    this.candleProps = {
+        open: [],
+        high: [],
+        low: [],
+        close: [],
+        volume: [],
+        vwp: []
+    };
+
+    if (config.indicator === undefined)
+        throw Error('TalibSync: You must specify an indicator, e.g. sma or macd');
+    else
+        this.indName = config.indicator;
+
+
+    this.indLength = config.length;
+    this.age = 0;
+    log.debug('*** Usage info for Talib ' + talib.version + ' indicator', this.indName, ':\n', talib.explain(this.indName.toUpperCase()));
+}
+
+
+Indicator.prototype.addCandle = function (candle) {
+    this.age++;  
+    this.candleProps.open.push(candle.open);
+    this.candleProps.high.push(candle.high);
+    this.candleProps.low.push(candle.low);
+    this.candleProps.close.push(candle.close);
+    this.candleProps.volume.push(candle.volume);
+    this.candleProps.vwp.push(candle.vwp);
+
+    if(this.age > this.indLength) {
+        this.candleProps.open.shift();
+        this.candleProps.high.shift();
+        this.candleProps.low.shift();
+        this.candleProps.close.shift();
+        this.candleProps.volume.shift();
+        this.candleProps.vwp.shift();
+    }
+}
+
+
+Indicator.prototype.update = function (candle) {
+    this.addCandle(candle) ;  
+
+    return new Promise((resolve, reject) => {       
+        talibrunner = gekkotalib[this.indName].create(this.config.options);
+        talibrunner(this.candleProps, function(err, talibResults) {
+            if (err) {
+                reject(err);
+            }
+            else {
+                var result = false;
+                if (talibResults['outReal'].length > 0) {
+                   result = talibResults['outReal'][talibResults['outReal'].length-1];
+                }
+                else {
+                    result = talibResults;
+                }
+                resolve(result);
+            }
+        });
+    });
+}
+
+
+module.exports = Indicator;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Right now any native Gekko indicator need to run synchronous, impossible to use async execution or callbacks. Since talib und tulip indicators are async, so they need to use the asyncIndicatorRunner, where Gekko is calculating it behind the scenes before the strategy update is called.


* **What is the new behavior (if this is a feature change)?**

The existing approach works nice until you need async behavior inside the strategy on your own. E.g. this is the case if you write multi-timeframe strategies with custom candle batching. With this async talib indicator implementation, it is possible to add and calculate talib indicators like any other native gekko indicator, from inside the strategy.



* **Other information**:
