### PR TITLE
bugfix #2548 if no strategy.historySize found, than get it from tradingAdvisor

### DIFF
--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -37,7 +37,6 @@ var Base = function(settings) {
   this.settings = settings;
   this.tradingAdvisor = config.tradingAdvisor;
   // defaults
-  this.requiredHistory = 0;
   this.priceValue = 'close';
   this.indicators = {};
   this.asyncTick = false;
@@ -68,6 +67,11 @@ var Base = function(settings) {
 
   // let's run the implemented starting point
   this.init();
+
+  //if no requiredHistory was provided, set default from tradingAdvisor
+  if (!this.requiredHistory){
+    this.requiredHistory = config.tradingAdvisor.historySize;
+  }
 
   if(!config.debug || !this.log)
     this.log = function() {};

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -69,7 +69,7 @@ var Base = function(settings) {
   this.init();
 
   //if no requiredHistory was provided, set default from tradingAdvisor
-  if (!this.requiredHistory){
+  if (!_.isNumber(this.requiredHistory)){
     this.requiredHistory = config.tradingAdvisor.historySize;
   }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix #2548

* **What is the current behavior?** (You can also link to an open issue here)
When using tulip indicators the update function is not called. see  #2548
this behavior is only in standalone mode, because no historySize is in sample-config is provided. That's why isAllowedToCheck is always undefined and this.completedWarmup is always false.

* **What is the new behavior (if this is a feature change)?**
Now checking after init() method if historySize is provided. If no than take the historySize from tradingAdvisor.

* **Other information**:
To  provide extra historySize in settings is not very convinient, it is better to have just one place in tradingAdvisor.historySize but with the option to override in settings.historySize.
