### PR TITLE
Fixed getFee() for binance exchange

### DIFF
--- a/core/pipeline.js
+++ b/core/pipeline.js
@@ -6,7 +6,7 @@
   all enabled plugins are actually supported by that market.
 
   Read more here:
-  https://gekko.wizbit/docs/internals/architecture.html
+  https://gekko.wizb.it/docs/internals/architecture.html
 
 */
 

--- a/docs/extending/add_an_exchange.md
+++ b/docs/extending/add_an_exchange.md
@@ -48,7 +48,7 @@ The callback needs to have the parameters of `err` and `ticker`. Ticker needs to
 
     this.exchange.getFee(callback)
 
-The callback needs to have the parameters of `err` and `fee`. Fee is a float that represents the amount the exchange takes out of the orders Gekko places. If an exchange has a fee of 0.2% this should be `0.0002`.
+The callback needs to have the parameters of `err` and `fee`. Fee is a float that represents the amount the exchange takes out of the orders Gekko places. If an exchange has a fee of 0.2% this should be `0.002`.
 
 ### getPortfolio
 

--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -63,7 +63,7 @@ const Trader = function(config) {
     // Though we can deduce feePercent based
     // on user fee tracked through `this.getFee`.
     // Set default here, overwrite in getFee.
-    this.fee = 0.1;
+    this.fee = 0.001;
     // Set the proper fee asap.
     this.getFee(_.noop);
 
@@ -212,13 +212,22 @@ Trader.prototype.getFee = function(callback) {
     if(err)  {
       return callback(err);
     }
-
     const basepoints = data.makerCommission;
 
+    /** Binance raw response
+    { makerCommission: 10,
+      takerCommission: 10,
+      buyerCommission: 0,
+      sellerCommission: 0,
+      canTrade: true,
+      canWithdraw: true,
+      canDeposit: true,
+      So to get decimal representation of fee we actually need to divide by 10000
+    */
     // note non standard func, see constructor
-    this.fee = basepoints / 100;
+    this.fee = basepoints / 10000;
 
-    callback(undefined, basepoints / 100);
+    callback(undefined, this.fee);
   }
 
   const fetch = cb => this.binance.account({}, this.handleResponse('getFee', cb));

--- a/web/routes/baseConfig.js
+++ b/web/routes/baseConfig.js
@@ -77,6 +77,11 @@ config.mongodb = {
   }]
 }
 
+config.adviceWriter = {
+  enabled: false,
+  muteSoft: true,
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //                       CONFIGURING BACKTESTING
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
binance.getFee() - 0.1
bitfinex.getFee() - 0.002

* **What is the new behavior (if this is a feature change)?**
binance.getFee() - 0.001
bitfinex.getFee() - 0.002



* **Other information**:
Here is binance raw response. As you can see binance gives us fee as 10, when I would expect 0.1 
{ makerCommission: 10,
  takerCommission: 10,
  buyerCommission: 0,
  sellerCommission: 0,
  canTrade: true,
  canWithdraw: true,
  canDeposit: true,

So we need to divide by 10000 to get decimal fee for binance