### PR TITLE
ExchangeChecker: adding missing config reference

### DIFF
--- a/exchange/exchangeChecker.js
+++ b/exchange/exchangeChecker.js
@@ -2,6 +2,8 @@ const _ = require('lodash');
 const fs = require('fs');
 const moment = require('moment');
 const errors = require('./exchangeErrors');
+const util = require('../core/util');
+const config = util.getConfig();
 
 const Checker = function() {
   _.bindAll(this);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When assessing whether the market can provide full market history when the selected exchange has a `exchangeMaxHistoryAge` property (as of now, only coingi has that property), the `ExchangeChecker` refers to the gekko process `config`, whose reference was removed in 29b0dde584a3ef432f396b32cb93b673c4c5b. The gekko process will therefore crash.    
I haven't witnessed this behavior, as I uncovered the bug while performing a rebase from gekko into an other project. But I assume this is what would happen when someone wants to run an `importer` market from coingi.

* **What is the new behavior (if this is a feature change)?**
The gekko process will assess correctly whether it can or cannot fetch full market history. Assumed, untested. But seems rather straightforward.


* **Other information**:
