### PR TITLE
[DOCS] plugins.md: removed trailing comma from code example (lines 78 and 133).

### DIFF
--- a/docs/commandline/plugins.md
+++ b/docs/commandline/plugins.md
@@ -75,7 +75,7 @@ Go to the config and configure it like this:
       simulationBalance: {
         // these are in the unit types configured in the watcher.
         asset: 1,
-        currency: 100,
+        currency: 100
       },
       // only want report after a sell? set to `false`.
       verbose: false,
@@ -130,7 +130,7 @@ Mailer will automatically email you whenever Gekko has a new advice.
       // guarantee that your email address & password are safe!
 
       password: '',       // Your GMail Password - if not supplied Gekko will prompt on startup.
-      tag: '[GEKKO] ',      // Prefix all EMail subject lines with this
+      tag: '[GEKKO] '      // Prefix all EMail subject lines with this
     }
 
 - enabled indicates whether this is on or off.


### PR DESCRIPTION
[DOCS] nit: removed trailing comma from code example (lines 78 and 133).

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The example will lead to an error, "," not consistent 78 & 133


* **What is the new behavior (if this is a feature change)?**
The example will work


* **Other information**:
