### PR TITLE
[DOCS] about_gekko.md: add consistent information for the risk of someone having access to your gekko

### DIFF
--- a/docs/introduction/about_gekko.md
+++ b/docs/introduction/about_gekko.md
@@ -47,6 +47,16 @@ Read more in the [architecture documentation](../internals/architecture.md).
 * The title is inspired by [Bateman](https://github.com/fearofcode/bateman).
 * This project is inspired by the [GoxTradingBot](https://github.com/virtimus/GoxTradingBot/) Chrome plugin (which in turn is inspired by [Goomboo's journal](https://bitcointalk.org/index.php?topic=60501.0)).
 
+## The risk of someone having access to your gekko:
+
+There are various risks associated with the appropriation of your Gekko account by someone else:
+
+- they can see your bots
+- they can start/stop bots
+- they can run many backtests that will basically DOS your server
+
+To protect yourself, do not disclose any information about your Gekko.
+
 ## Final
 
 If Gekko helped you in any way, you can always leave me a tip at (BTC) 13r1jyivitShUiv9FJvjLH7Nh1ZZptumwW


### PR DESCRIPTION
Add consistent information for the risk of someone having access to your gekko by establishing what can happen.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update


* **What is the current behavior?** (You can also link to an open issue here)
None information about this subject


* **What is the new behavior (if this is a feature change)?**
Add consistent information for the risk of someone having access to your gekko by establishing what can happen.


* **Other information**:
