### PR TITLE
Feature/backtest tweaks

### DIFF
--- a/core/tools/dateRangeScanner.js
+++ b/core/tools/dateRangeScanner.js
@@ -92,13 +92,13 @@ var scan = function(done) {
             iterator.to -= BATCH_SIZE * 60;
           },
           () => {
-            
-            if(!_.size(batches))
-              util.die('Not enough data to work with (please manually set a valid `backtest.daterange`)..', true);
+            if(batches.length === 0) {
+              return done(null, [], reader);
+            }
 
             // batches is now a list like
             // [ {from: unix, to: unix } ]
-            
+
             var ranges = [ batches.shift() ];
 
             _.each(batches, batch => {
@@ -112,6 +112,7 @@ var scan = function(done) {
             // we have been counting chronologically reversed
             // (backwards, from now into the past), flip definitions
             ranges = ranges.reverse();
+
             _.map(ranges, r => {
               return {
                 from: r.to,

--- a/exchange/orders/sticky.js
+++ b/exchange/orders/sticky.js
@@ -52,15 +52,19 @@ class StickyOrder extends BaseOrder {
     this.initialLimit = params.initialLimit;
 
     if(side === 'buy') {
-      if(params.limit)
+      if(params.limit) {
         this.limit = this.roundPrice(params.limit);
-      else
+      } else {
+        this.noLimit = true;
         this.limit = Infinity;
+      }
     } else {
-      if(params.limit)
+      if(params.limit) {
         this.limit = this.roundPrice(params.limit);
-      else
+      } else {
+        this.noLimit = true;
         this.limit = -Infinity;
+      }
     }
 
     this.status = states.SUBMITTED;
@@ -76,6 +80,7 @@ class StickyOrder extends BaseOrder {
     } else {
       this.api.getTicker((err, ticker) => {
         if(this.handleError(err)) {
+          console.log(new Date, 'error get ticker');
           return;
         }
 
@@ -98,7 +103,7 @@ class StickyOrder extends BaseOrder {
 
     if(this.side === 'buy') {
 
-      if(ticker.bid >= this.limit) {
+      if(!this.noLimit && ticker.bid >= this.limit) {
         return r(this.limit);
       }
 
@@ -116,7 +121,7 @@ class StickyOrder extends BaseOrder {
 
     } else if(this.side === 'sell') {
 
-      if(ticker.ask <= this.limit) {
+      if(!this.noLimit && ticker.ask <= this.limit) {
         return r(this.limit);
       }
 
@@ -283,6 +288,7 @@ class StickyOrder extends BaseOrder {
 
         this.api.getTicker((err, ticker) => {
           if(this.handleError(err)) {
+            console.log(new Date, 'getTicker error');
             return;
           }
 
@@ -499,6 +505,7 @@ class StickyOrder extends BaseOrder {
 
     this.api.cancelOrder(this.id, (err, filled, data) => {
       if(this.handleError(err)) {
+        console.log(new Date, 'error cancel');
         return;
       }
 

--- a/exchange/wrappers/bitfinex-markets.json
+++ b/exchange/wrappers/bitfinex-markets.json
@@ -13,7 +13,6 @@
     "EOS",
     "SAN",
     "OMG",
-    "BCH",
     "NEO",
     "ETP",
     "QTM",
@@ -58,7 +57,6 @@
     "XVG",
     "BCI",
     "MKR",
-    "VEN",
     "KNC",
     "POA",
     "LYM",
@@ -87,7 +85,30 @@
     "BNT",
     "ABS",
     "XRA",
-    "MAN"
+    "MAN",
+    "BBN",
+    "NIO",
+    "DGX",
+    "VET",
+    "UTN",
+    "TKN",
+    "GOT",
+    "XTZ",
+    "CNN",
+    "BOX",
+    "MGO",
+    "RTE",
+    "YGG",
+    "MLN",
+    "WTC",
+    "CSX",
+    "OMN",
+    "INT",
+    "DRN",
+    "PNK",
+    "DGB",
+    "BSV",
+    "BAB"
   ],
   "currencies": [
     "USD",
@@ -135,7 +156,7 @@
         "ETH"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.06",
         "unit": "asset"
       }
     },
@@ -145,7 +166,7 @@
         "ETH"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.06",
         "unit": "asset"
       }
     },
@@ -155,7 +176,7 @@
         "ETC"
       ],
       "minimalOrder": {
-        "amount": "0.8",
+        "amount": "2.0",
         "unit": "asset"
       }
     },
@@ -165,7 +186,7 @@
         "ETC"
       ],
       "minimalOrder": {
-        "amount": "0.8",
+        "amount": "2.0",
         "unit": "asset"
       }
     },
@@ -175,7 +196,7 @@
         "RRT"
       ],
       "minimalOrder": {
-        "amount": "224.0",
+        "amount": "294.0",
         "unit": "asset"
       }
     },
@@ -185,7 +206,7 @@
         "RRT"
       ],
       "minimalOrder": {
-        "amount": "224.0",
+        "amount": "294.0",
         "unit": "asset"
       }
     },
@@ -195,7 +216,7 @@
         "ZEC"
       ],
       "minimalOrder": {
-        "amount": "0.06",
+        "amount": "0.1",
         "unit": "asset"
       }
     },
@@ -205,7 +226,7 @@
         "ZEC"
       ],
       "minimalOrder": {
-        "amount": "0.06",
+        "amount": "0.1",
         "unit": "asset"
       }
     },
@@ -235,7 +256,7 @@
         "DSH"
       ],
       "minimalOrder": {
-        "amount": "0.06",
+        "amount": "0.08",
         "unit": "asset"
       }
     },
@@ -245,7 +266,7 @@
         "DSH"
       ],
       "minimalOrder": {
-        "amount": "0.06",
+        "amount": "0.08",
         "unit": "asset"
       }
     },
@@ -275,7 +296,7 @@
         "XRP"
       ],
       "minimalOrder": {
-        "amount": "30.0",
+        "amount": "38.0",
         "unit": "asset"
       }
     },
@@ -285,7 +306,7 @@
         "XRP"
       ],
       "minimalOrder": {
-        "amount": "30.0",
+        "amount": "38.0",
         "unit": "asset"
       }
     },
@@ -295,7 +316,7 @@
         "IOT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -305,7 +326,7 @@
         "IOT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -315,7 +336,7 @@
         "IOT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -355,7 +376,7 @@
         "SAN"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -365,7 +386,7 @@
         "SAN"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -375,7 +396,7 @@
         "SAN"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -385,7 +406,7 @@
         "OMG"
       ],
       "minimalOrder": {
-        "amount": "2.0",
+        "amount": "4.0",
         "unit": "asset"
       }
     },
@@ -395,7 +416,7 @@
         "OMG"
       ],
       "minimalOrder": {
-        "amount": "2.0",
+        "amount": "4.0",
         "unit": "asset"
       }
     },
@@ -405,37 +426,7 @@
         "OMG"
       ],
       "minimalOrder": {
-        "amount": "2.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "BCH"
-      ],
-      "minimalOrder": {
-        "amount": "0.02",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "BCH"
-      ],
-      "minimalOrder": {
-        "amount": "0.02",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "BCH"
-      ],
-      "minimalOrder": {
-        "amount": "0.02",
+        "amount": "4.0",
         "unit": "asset"
       }
     },
@@ -445,7 +436,7 @@
         "NEO"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.8",
         "unit": "asset"
       }
     },
@@ -455,7 +446,7 @@
         "NEO"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.8",
         "unit": "asset"
       }
     },
@@ -465,7 +456,7 @@
         "NEO"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.8",
         "unit": "asset"
       }
     },
@@ -475,7 +466,7 @@
         "ETP"
       ],
       "minimalOrder": {
-        "amount": "10.0",
+        "amount": "8.0",
         "unit": "asset"
       }
     },
@@ -485,7 +476,7 @@
         "ETP"
       ],
       "minimalOrder": {
-        "amount": "10.0",
+        "amount": "8.0",
         "unit": "asset"
       }
     },
@@ -495,7 +486,7 @@
         "ETP"
       ],
       "minimalOrder": {
-        "amount": "10.0",
+        "amount": "8.0",
         "unit": "asset"
       }
     },
@@ -505,7 +496,7 @@
         "QTM"
       ],
       "minimalOrder": {
-        "amount": "2.0",
+        "amount": "4.0",
         "unit": "asset"
       }
     },
@@ -515,7 +506,7 @@
         "QTM"
       ],
       "minimalOrder": {
-        "amount": "2.0",
+        "amount": "4.0",
         "unit": "asset"
       }
     },
@@ -525,7 +516,7 @@
         "QTM"
       ],
       "minimalOrder": {
-        "amount": "2.0",
+        "amount": "4.0",
         "unit": "asset"
       }
     },
@@ -535,7 +526,7 @@
         "AVT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "36.0",
         "unit": "asset"
       }
     },
@@ -545,7 +536,7 @@
         "AVT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "36.0",
         "unit": "asset"
       }
     },
@@ -555,7 +546,7 @@
         "AVT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "36.0",
         "unit": "asset"
       }
     },
@@ -595,7 +586,7 @@
         "BTG"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.6",
         "unit": "asset"
       }
     },
@@ -605,7 +596,7 @@
         "BTG"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.6",
         "unit": "asset"
       }
     },
@@ -615,7 +606,7 @@
         "DAT"
       ],
       "minimalOrder": {
-        "amount": "256.0",
+        "amount": "352.0",
         "unit": "asset"
       }
     },
@@ -625,7 +616,7 @@
         "DAT"
       ],
       "minimalOrder": {
-        "amount": "256.0",
+        "amount": "352.0",
         "unit": "asset"
       }
     },
@@ -635,7 +626,7 @@
         "DAT"
       ],
       "minimalOrder": {
-        "amount": "256.0",
+        "amount": "352.0",
         "unit": "asset"
       }
     },
@@ -675,7 +666,7 @@
         "YYW"
       ],
       "minimalOrder": {
-        "amount": "374.0",
+        "amount": "510.0",
         "unit": "asset"
       }
     },
@@ -685,7 +676,7 @@
         "YYW"
       ],
       "minimalOrder": {
-        "amount": "374.0",
+        "amount": "510.0",
         "unit": "asset"
       }
     },
@@ -695,7 +686,7 @@
         "YYW"
       ],
       "minimalOrder": {
-        "amount": "374.0",
+        "amount": "510.0",
         "unit": "asset"
       }
     },
@@ -705,7 +696,7 @@
         "GNT"
       ],
       "minimalOrder": {
-        "amount": "54.0",
+        "amount": "82.0",
         "unit": "asset"
       }
     },
@@ -715,7 +706,7 @@
         "GNT"
       ],
       "minimalOrder": {
-        "amount": "54.0",
+        "amount": "82.0",
         "unit": "asset"
       }
     },
@@ -725,7 +716,7 @@
         "GNT"
       ],
       "minimalOrder": {
-        "amount": "54.0",
+        "amount": "82.0",
         "unit": "asset"
       }
     },
@@ -735,7 +726,7 @@
         "SNT"
       ],
       "minimalOrder": {
-        "amount": "216.0",
+        "amount": "334.0",
         "unit": "asset"
       }
     },
@@ -745,7 +736,7 @@
         "SNT"
       ],
       "minimalOrder": {
-        "amount": "216.0",
+        "amount": "334.0",
         "unit": "asset"
       }
     },
@@ -755,7 +746,7 @@
         "SNT"
       ],
       "minimalOrder": {
-        "amount": "216.0",
+        "amount": "334.0",
         "unit": "asset"
       }
     },
@@ -765,7 +756,7 @@
         "IOT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -775,7 +766,7 @@
         "BAT"
       ],
       "minimalOrder": {
-        "amount": "50.0",
+        "amount": "70.0",
         "unit": "asset"
       }
     },
@@ -785,7 +776,7 @@
         "BAT"
       ],
       "minimalOrder": {
-        "amount": "50.0",
+        "amount": "70.0",
         "unit": "asset"
       }
     },
@@ -795,7 +786,7 @@
         "BAT"
       ],
       "minimalOrder": {
-        "amount": "50.0",
+        "amount": "70.0",
         "unit": "asset"
       }
     },
@@ -805,7 +796,7 @@
         "MNA"
       ],
       "minimalOrder": {
-        "amount": "132.0",
+        "amount": "164.0",
         "unit": "asset"
       }
     },
@@ -815,7 +806,7 @@
         "MNA"
       ],
       "minimalOrder": {
-        "amount": "132.0",
+        "amount": "164.0",
         "unit": "asset"
       }
     },
@@ -825,7 +816,7 @@
         "MNA"
       ],
       "minimalOrder": {
-        "amount": "132.0",
+        "amount": "164.0",
         "unit": "asset"
       }
     },
@@ -835,7 +826,7 @@
         "FUN"
       ],
       "minimalOrder": {
-        "amount": "554.0",
+        "amount": "1196.0",
         "unit": "asset"
       }
     },
@@ -845,7 +836,7 @@
         "FUN"
       ],
       "minimalOrder": {
-        "amount": "554.0",
+        "amount": "1196.0",
         "unit": "asset"
       }
     },
@@ -855,7 +846,7 @@
         "FUN"
       ],
       "minimalOrder": {
-        "amount": "554.0",
+        "amount": "1196.0",
         "unit": "asset"
       }
     },
@@ -865,7 +856,7 @@
         "ZRX"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "20.0",
         "unit": "asset"
       }
     },
@@ -875,7 +866,7 @@
         "ZRX"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "20.0",
         "unit": "asset"
       }
     },
@@ -885,7 +876,7 @@
         "ZRX"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "20.0",
         "unit": "asset"
       }
     },
@@ -895,7 +886,7 @@
         "TNB"
       ],
       "minimalOrder": {
-        "amount": "652.0",
+        "amount": "1418.0",
         "unit": "asset"
       }
     },
@@ -905,7 +896,7 @@
         "TNB"
       ],
       "minimalOrder": {
-        "amount": "652.0",
+        "amount": "1418.0",
         "unit": "asset"
       }
     },
@@ -915,7 +906,7 @@
         "TNB"
       ],
       "minimalOrder": {
-        "amount": "652.0",
+        "amount": "1418.0",
         "unit": "asset"
       }
     },
@@ -925,7 +916,7 @@
         "SPK"
       ],
       "minimalOrder": {
-        "amount": "184.0",
+        "amount": "320.0",
         "unit": "asset"
       }
     },
@@ -935,7 +926,7 @@
         "SPK"
       ],
       "minimalOrder": {
-        "amount": "184.0",
+        "amount": "320.0",
         "unit": "asset"
       }
     },
@@ -945,7 +936,7 @@
         "SPK"
       ],
       "minimalOrder": {
-        "amount": "184.0",
+        "amount": "320.0",
         "unit": "asset"
       }
     },
@@ -955,7 +946,7 @@
         "TRX"
       ],
       "minimalOrder": {
-        "amount": "410.0",
+        "amount": "548.0",
         "unit": "asset"
       }
     },
@@ -965,7 +956,7 @@
         "TRX"
       ],
       "minimalOrder": {
-        "amount": "410.0",
+        "amount": "548.0",
         "unit": "asset"
       }
     },
@@ -975,7 +966,7 @@
         "TRX"
       ],
       "minimalOrder": {
-        "amount": "410.0",
+        "amount": "548.0",
         "unit": "asset"
       }
     },
@@ -985,7 +976,7 @@
         "RCN"
       ],
       "minimalOrder": {
-        "amount": "322.0",
+        "amount": "518.0",
         "unit": "asset"
       }
     },
@@ -995,7 +986,7 @@
         "RCN"
       ],
       "minimalOrder": {
-        "amount": "322.0",
+        "amount": "518.0",
         "unit": "asset"
       }
     },
@@ -1005,7 +996,7 @@
         "RCN"
       ],
       "minimalOrder": {
-        "amount": "322.0",
+        "amount": "518.0",
         "unit": "asset"
       }
     },
@@ -1015,7 +1006,7 @@
         "RLC"
       ],
       "minimalOrder": {
-        "amount": "28.0",
+        "amount": "32.0",
         "unit": "asset"
       }
     },
@@ -1025,7 +1016,7 @@
         "RLC"
       ],
       "minimalOrder": {
-        "amount": "28.0",
+        "amount": "32.0",
         "unit": "asset"
       }
     },
@@ -1035,7 +1026,7 @@
         "RLC"
       ],
       "minimalOrder": {
-        "amount": "28.0",
+        "amount": "32.0",
         "unit": "asset"
       }
     },
@@ -1045,7 +1036,7 @@
         "AID"
       ],
       "minimalOrder": {
-        "amount": "122.0",
+        "amount": "236.0",
         "unit": "asset"
       }
     },
@@ -1055,7 +1046,7 @@
         "AID"
       ],
       "minimalOrder": {
-        "amount": "122.0",
+        "amount": "236.0",
         "unit": "asset"
       }
     },
@@ -1065,7 +1056,7 @@
         "AID"
       ],
       "minimalOrder": {
-        "amount": "122.0",
+        "amount": "236.0",
         "unit": "asset"
       }
     },
@@ -1075,7 +1066,7 @@
         "SNG"
       ],
       "minimalOrder": {
-        "amount": "452.0",
+        "amount": "562.0",
         "unit": "asset"
       }
     },
@@ -1085,7 +1076,7 @@
         "SNG"
       ],
       "minimalOrder": {
-        "amount": "452.0",
+        "amount": "562.0",
         "unit": "asset"
       }
     },
@@ -1095,7 +1086,7 @@
         "SNG"
       ],
       "minimalOrder": {
-        "amount": "452.0",
+        "amount": "562.0",
         "unit": "asset"
       }
     },
@@ -1105,7 +1096,7 @@
         "REP"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "1.0",
         "unit": "asset"
       }
     },
@@ -1115,7 +1106,7 @@
         "REP"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "1.0",
         "unit": "asset"
       }
     },
@@ -1125,7 +1116,7 @@
         "REP"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "1.0",
         "unit": "asset"
       }
     },
@@ -1135,7 +1126,7 @@
         "ELF"
       ],
       "minimalOrder": {
-        "amount": "20.0",
+        "amount": "46.0",
         "unit": "asset"
       }
     },
@@ -1145,7 +1136,7 @@
         "ELF"
       ],
       "minimalOrder": {
-        "amount": "20.0",
+        "amount": "46.0",
         "unit": "asset"
       }
     },
@@ -1155,7 +1146,7 @@
         "ELF"
       ],
       "minimalOrder": {
-        "amount": "20.0",
+        "amount": "46.0",
         "unit": "asset"
       }
     },
@@ -1175,7 +1166,7 @@
         "ETH"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.06",
         "unit": "asset"
       }
     },
@@ -1185,7 +1176,7 @@
         "ETH"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.06",
         "unit": "asset"
       }
     },
@@ -1195,7 +1186,7 @@
         "ETH"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.06",
         "unit": "asset"
       }
     },
@@ -1205,7 +1196,7 @@
         "NEO"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.8",
         "unit": "asset"
       }
     },
@@ -1215,7 +1206,7 @@
         "NEO"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.8",
         "unit": "asset"
       }
     },
@@ -1225,7 +1216,7 @@
         "NEO"
       ],
       "minimalOrder": {
-        "amount": "0.4",
+        "amount": "0.8",
         "unit": "asset"
       }
     },
@@ -1265,7 +1256,7 @@
         "IOT"
       ],
       "minimalOrder": {
-        "amount": "16.0",
+        "amount": "24.0",
         "unit": "asset"
       }
     },
@@ -1275,6 +1266,626 @@
         "IOT"
       ],
       "minimalOrder": {
+        "amount": "24.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "IOS"
+      ],
+      "minimalOrder": {
+        "amount": "1170.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "IOS"
+      ],
+      "minimalOrder": {
+        "amount": "1170.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "IOS"
+      ],
+      "minimalOrder": {
+        "amount": "1170.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "AIO"
+      ],
+      "minimalOrder": {
+        "amount": "34.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "AIO"
+      ],
+      "minimalOrder": {
+        "amount": "34.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "AIO"
+      ],
+      "minimalOrder": {
+        "amount": "34.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "REQ"
+      ],
+      "minimalOrder": {
+        "amount": "302.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "REQ"
+      ],
+      "minimalOrder": {
+        "amount": "302.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "REQ"
+      ],
+      "minimalOrder": {
+        "amount": "302.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "RDN"
+      ],
+      "minimalOrder": {
+        "amount": "32.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "RDN"
+      ],
+      "minimalOrder": {
+        "amount": "32.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "RDN"
+      ],
+      "minimalOrder": {
+        "amount": "32.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "LRC"
+      ],
+      "minimalOrder": {
+        "amount": "144.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "LRC"
+      ],
+      "minimalOrder": {
+        "amount": "144.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "LRC"
+      ],
+      "minimalOrder": {
+        "amount": "144.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "WAX"
+      ],
+      "minimalOrder": {
+        "amount": "166.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "WAX"
+      ],
+      "minimalOrder": {
+        "amount": "166.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "WAX"
+      ],
+      "minimalOrder": {
+        "amount": "166.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "DAI"
+      ],
+      "minimalOrder": {
+        "amount": "10.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "DAI"
+      ],
+      "minimalOrder": {
+        "amount": "10.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "DAI"
+      ],
+      "minimalOrder": {
+        "amount": "10.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "CFI"
+      ],
+      "minimalOrder": {
+        "amount": "566.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "CFI"
+      ],
+      "minimalOrder": {
+        "amount": "566.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "CFI"
+      ],
+      "minimalOrder": {
+        "amount": "566.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "AGI"
+      ],
+      "minimalOrder": {
+        "amount": "268.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "AGI"
+      ],
+      "minimalOrder": {
+        "amount": "268.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "AGI"
+      ],
+      "minimalOrder": {
+        "amount": "268.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "BFT"
+      ],
+      "minimalOrder": {
+        "amount": "272.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "BFT"
+      ],
+      "minimalOrder": {
+        "amount": "272.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "BFT"
+      ],
+      "minimalOrder": {
+        "amount": "272.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "MTN"
+      ],
+      "minimalOrder": {
+        "amount": "606.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "MTN"
+      ],
+      "minimalOrder": {
+        "amount": "606.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "MTN"
+      ],
+      "minimalOrder": {
+        "amount": "606.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "ODE"
+      ],
+      "minimalOrder": {
+        "amount": "86.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "ODE"
+      ],
+      "minimalOrder": {
+        "amount": "86.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "ODE"
+      ],
+      "minimalOrder": {
+        "amount": "86.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "ANT"
+      ],
+      "minimalOrder": {
+        "amount": "22.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "ANT"
+      ],
+      "minimalOrder": {
+        "amount": "22.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "ANT"
+      ],
+      "minimalOrder": {
+        "amount": "22.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "DTH"
+      ],
+      "minimalOrder": {
+        "amount": "958.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "DTH"
+      ],
+      "minimalOrder": {
+        "amount": "958.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "DTH"
+      ],
+      "minimalOrder": {
+        "amount": "958.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "MIT"
+      ],
+      "minimalOrder": {
+        "amount": "44.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "MIT"
+      ],
+      "minimalOrder": {
+        "amount": "44.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "MIT"
+      ],
+      "minimalOrder": {
+        "amount": "44.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "STJ"
+      ],
+      "minimalOrder": {
+        "amount": "44.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "STJ"
+      ],
+      "minimalOrder": {
+        "amount": "44.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "STJ"
+      ],
+      "minimalOrder": {
+        "amount": "44.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "XLM"
+      ],
+      "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "EUR",
+        "XLM"
+      ],
+      "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "JPY",
+        "XLM"
+      ],
+      "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "GBP",
+        "XLM"
+      ],
+      "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "XLM"
+      ],
+      "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "XLM"
+      ],
+      "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "XVG"
+      ],
+      "minimalOrder": {
+        "amount": "1024.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "EUR",
+        "XVG"
+      ],
+      "minimalOrder": {
+        "amount": "1024.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "JPY",
+        "XVG"
+      ],
+      "minimalOrder": {
+        "amount": "1024.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "GBP",
+        "XVG"
+      ],
+      "minimalOrder": {
+        "amount": "1024.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "XVG"
+      ],
+      "minimalOrder": {
+        "amount": "1024.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "XVG"
+      ],
+      "minimalOrder": {
+        "amount": "1024.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "BCI"
+      ],
+      "minimalOrder": {
+        "amount": "16.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "BCI"
+      ],
+      "minimalOrder": {
         "amount": "16.0",
         "unit": "asset"
       }
@@ -1282,630 +1893,10 @@
     {
       "pair": [
         "USD",
-        "IOS"
-      ],
-      "minimalOrder": {
-        "amount": "596.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "IOS"
-      ],
-      "minimalOrder": {
-        "amount": "596.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "IOS"
-      ],
-      "minimalOrder": {
-        "amount": "596.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "AIO"
-      ],
-      "minimalOrder": {
-        "amount": "20.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "AIO"
-      ],
-      "minimalOrder": {
-        "amount": "20.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "AIO"
-      ],
-      "minimalOrder": {
-        "amount": "20.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "REQ"
-      ],
-      "minimalOrder": {
-        "amount": "206.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "REQ"
-      ],
-      "minimalOrder": {
-        "amount": "206.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "REQ"
-      ],
-      "minimalOrder": {
-        "amount": "206.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "RDN"
-      ],
-      "minimalOrder": {
-        "amount": "18.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "RDN"
-      ],
-      "minimalOrder": {
-        "amount": "18.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "RDN"
-      ],
-      "minimalOrder": {
-        "amount": "18.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "LRC"
-      ],
-      "minimalOrder": {
-        "amount": "80.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "LRC"
-      ],
-      "minimalOrder": {
-        "amount": "80.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "LRC"
-      ],
-      "minimalOrder": {
-        "amount": "80.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "WAX"
-      ],
-      "minimalOrder": {
-        "amount": "112.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "WAX"
-      ],
-      "minimalOrder": {
-        "amount": "112.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "WAX"
-      ],
-      "minimalOrder": {
-        "amount": "112.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "DAI"
-      ],
-      "minimalOrder": {
-        "amount": "10.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "DAI"
-      ],
-      "minimalOrder": {
-        "amount": "10.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "DAI"
-      ],
-      "minimalOrder": {
-        "amount": "10.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "CFI"
-      ],
-      "minimalOrder": {
-        "amount": "368.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "CFI"
-      ],
-      "minimalOrder": {
-        "amount": "368.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "CFI"
-      ],
-      "minimalOrder": {
-        "amount": "368.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "AGI"
-      ],
-      "minimalOrder": {
-        "amount": "158.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "AGI"
-      ],
-      "minimalOrder": {
-        "amount": "158.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "AGI"
-      ],
-      "minimalOrder": {
-        "amount": "158.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "BFT"
-      ],
-      "minimalOrder": {
-        "amount": "180.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "BFT"
-      ],
-      "minimalOrder": {
-        "amount": "180.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "BFT"
-      ],
-      "minimalOrder": {
-        "amount": "180.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "MTN"
-      ],
-      "minimalOrder": {
-        "amount": "334.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "MTN"
-      ],
-      "minimalOrder": {
-        "amount": "334.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "MTN"
-      ],
-      "minimalOrder": {
-        "amount": "334.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "ODE"
-      ],
-      "minimalOrder": {
-        "amount": "50.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "ODE"
-      ],
-      "minimalOrder": {
-        "amount": "50.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "ODE"
-      ],
-      "minimalOrder": {
-        "amount": "50.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "ANT"
-      ],
-      "minimalOrder": {
-        "amount": "8.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "ANT"
-      ],
-      "minimalOrder": {
-        "amount": "8.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "ANT"
-      ],
-      "minimalOrder": {
-        "amount": "8.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "DTH"
-      ],
-      "minimalOrder": {
-        "amount": "304.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "DTH"
-      ],
-      "minimalOrder": {
-        "amount": "304.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "DTH"
-      ],
-      "minimalOrder": {
-        "amount": "304.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "MIT"
-      ],
-      "minimalOrder": {
-        "amount": "30.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "MIT"
-      ],
-      "minimalOrder": {
-        "amount": "30.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "MIT"
-      ],
-      "minimalOrder": {
-        "amount": "30.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "STJ"
-      ],
-      "minimalOrder": {
-        "amount": "24.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "STJ"
-      ],
-      "minimalOrder": {
-        "amount": "24.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "STJ"
-      ],
-      "minimalOrder": {
-        "amount": "24.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "XLM"
-      ],
-      "minimalOrder": {
-        "amount": "56.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "EUR",
-        "XLM"
-      ],
-      "minimalOrder": {
-        "amount": "56.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "JPY",
-        "XLM"
-      ],
-      "minimalOrder": {
-        "amount": "56.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "GBP",
-        "XLM"
-      ],
-      "minimalOrder": {
-        "amount": "56.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "XLM"
-      ],
-      "minimalOrder": {
-        "amount": "56.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "XLM"
-      ],
-      "minimalOrder": {
-        "amount": "56.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "XVG"
-      ],
-      "minimalOrder": {
-        "amount": "664.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "EUR",
-        "XVG"
-      ],
-      "minimalOrder": {
-        "amount": "664.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "JPY",
-        "XVG"
-      ],
-      "minimalOrder": {
-        "amount": "664.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "GBP",
-        "XVG"
-      ],
-      "minimalOrder": {
-        "amount": "664.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "XVG"
-      ],
-      "minimalOrder": {
-        "amount": "664.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "XVG"
-      ],
-      "minimalOrder": {
-        "amount": "664.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "BCI"
-      ],
-      "minimalOrder": {
-        "amount": "8.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "BCI"
-      ],
-      "minimalOrder": {
-        "amount": "8.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
         "MKR"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.04",
         "unit": "asset"
       }
     },
@@ -1915,7 +1906,7 @@
         "MKR"
       ],
       "minimalOrder": {
-        "amount": "0.02",
+        "amount": "0.04",
         "unit": "asset"
       }
     },
@@ -1925,37 +1916,7 @@
         "MKR"
       ],
       "minimalOrder": {
-        "amount": "0.02",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "USD",
-        "VEN"
-      ],
-      "minimalOrder": {
-        "amount": "10.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "BTC",
-        "VEN"
-      ],
-      "minimalOrder": {
-        "amount": "10.0",
-        "unit": "asset"
-      }
-    },
-    {
-      "pair": [
-        "ETH",
-        "VEN"
-      ],
-      "minimalOrder": {
-        "amount": "10.0",
+        "amount": "0.04",
         "unit": "asset"
       }
     },
@@ -1965,7 +1926,7 @@
         "KNC"
       ],
       "minimalOrder": {
-        "amount": "18.0",
+        "amount": "36.0",
         "unit": "asset"
       }
     },
@@ -1975,7 +1936,7 @@
         "KNC"
       ],
       "minimalOrder": {
-        "amount": "18.0",
+        "amount": "36.0",
         "unit": "asset"
       }
     },
@@ -1985,7 +1946,7 @@
         "KNC"
       ],
       "minimalOrder": {
-        "amount": "18.0",
+        "amount": "36.0",
         "unit": "asset"
       }
     },
@@ -1995,7 +1956,7 @@
         "POA"
       ],
       "minimalOrder": {
-        "amount": "102.0",
+        "amount": "184.0",
         "unit": "asset"
       }
     },
@@ -2005,7 +1966,7 @@
         "POA"
       ],
       "minimalOrder": {
-        "amount": "102.0",
+        "amount": "184.0",
         "unit": "asset"
       }
     },
@@ -2015,7 +1976,7 @@
         "POA"
       ],
       "minimalOrder": {
-        "amount": "102.0",
+        "amount": "184.0",
         "unit": "asset"
       }
     },
@@ -2025,7 +1986,7 @@
         "LYM"
       ],
       "minimalOrder": {
-        "amount": "584.0",
+        "amount": "874.0",
         "unit": "asset"
       }
     },
@@ -2035,7 +1996,7 @@
         "LYM"
       ],
       "minimalOrder": {
-        "amount": "584.0",
+        "amount": "874.0",
         "unit": "asset"
       }
     },
@@ -2045,7 +2006,7 @@
         "LYM"
       ],
       "minimalOrder": {
-        "amount": "584.0",
+        "amount": "874.0",
         "unit": "asset"
       }
     },
@@ -2055,7 +2016,7 @@
         "UTK"
       ],
       "minimalOrder": {
-        "amount": "218.0",
+        "amount": "426.0",
         "unit": "asset"
       }
     },
@@ -2065,7 +2026,7 @@
         "UTK"
       ],
       "minimalOrder": {
-        "amount": "218.0",
+        "amount": "426.0",
         "unit": "asset"
       }
     },
@@ -2075,7 +2036,7 @@
         "UTK"
       ],
       "minimalOrder": {
-        "amount": "218.0",
+        "amount": "426.0",
         "unit": "asset"
       }
     },
@@ -2085,7 +2046,7 @@
         "VEE"
       ],
       "minimalOrder": {
-        "amount": "774.0",
+        "amount": "1430.0",
         "unit": "asset"
       }
     },
@@ -2095,7 +2056,7 @@
         "VEE"
       ],
       "minimalOrder": {
-        "amount": "774.0",
+        "amount": "1430.0",
         "unit": "asset"
       }
     },
@@ -2105,7 +2066,7 @@
         "VEE"
       ],
       "minimalOrder": {
-        "amount": "774.0",
+        "amount": "1430.0",
         "unit": "asset"
       }
     },
@@ -2145,7 +2106,7 @@
         "ORS"
       ],
       "minimalOrder": {
-        "amount": "374.0",
+        "amount": "476.0",
         "unit": "asset"
       }
     },
@@ -2155,7 +2116,7 @@
         "ORS"
       ],
       "minimalOrder": {
-        "amount": "374.0",
+        "amount": "476.0",
         "unit": "asset"
       }
     },
@@ -2165,7 +2126,7 @@
         "ORS"
       ],
       "minimalOrder": {
-        "amount": "374.0",
+        "amount": "476.0",
         "unit": "asset"
       }
     },
@@ -2175,7 +2136,7 @@
         "AUC"
       ],
       "minimalOrder": {
-        "amount": "102.0",
+        "amount": "304.0",
         "unit": "asset"
       }
     },
@@ -2185,7 +2146,7 @@
         "AUC"
       ],
       "minimalOrder": {
-        "amount": "102.0",
+        "amount": "304.0",
         "unit": "asset"
       }
     },
@@ -2195,7 +2156,7 @@
         "AUC"
       ],
       "minimalOrder": {
-        "amount": "102.0",
+        "amount": "304.0",
         "unit": "asset"
       }
     },
@@ -2205,7 +2166,7 @@
         "POY"
       ],
       "minimalOrder": {
-        "amount": "44.0",
+        "amount": "70.0",
         "unit": "asset"
       }
     },
@@ -2215,7 +2176,7 @@
         "POY"
       ],
       "minimalOrder": {
-        "amount": "44.0",
+        "amount": "70.0",
         "unit": "asset"
       }
     },
@@ -2225,7 +2186,7 @@
         "POY"
       ],
       "minimalOrder": {
-        "amount": "44.0",
+        "amount": "70.0",
         "unit": "asset"
       }
     },
@@ -2235,7 +2196,7 @@
         "FSN"
       ],
       "minimalOrder": {
-        "amount": "8.0",
+        "amount": "14.0",
         "unit": "asset"
       }
     },
@@ -2245,7 +2206,7 @@
         "FSN"
       ],
       "minimalOrder": {
-        "amount": "8.0",
+        "amount": "14.0",
         "unit": "asset"
       }
     },
@@ -2255,7 +2216,7 @@
         "FSN"
       ],
       "minimalOrder": {
-        "amount": "8.0",
+        "amount": "14.0",
         "unit": "asset"
       }
     },
@@ -2265,7 +2226,7 @@
         "CBT"
       ],
       "minimalOrder": {
-        "amount": "562.0",
+        "amount": "1228.0",
         "unit": "asset"
       }
     },
@@ -2275,7 +2236,7 @@
         "CBT"
       ],
       "minimalOrder": {
-        "amount": "562.0",
+        "amount": "1228.0",
         "unit": "asset"
       }
     },
@@ -2285,7 +2246,7 @@
         "CBT"
       ],
       "minimalOrder": {
-        "amount": "562.0",
+        "amount": "1228.0",
         "unit": "asset"
       }
     },
@@ -2295,7 +2256,7 @@
         "ZCN"
       ],
       "minimalOrder": {
-        "amount": "52.0",
+        "amount": "90.0",
         "unit": "asset"
       }
     },
@@ -2305,7 +2266,7 @@
         "ZCN"
       ],
       "minimalOrder": {
-        "amount": "52.0",
+        "amount": "90.0",
         "unit": "asset"
       }
     },
@@ -2315,7 +2276,7 @@
         "ZCN"
       ],
       "minimalOrder": {
-        "amount": "52.0",
+        "amount": "90.0",
         "unit": "asset"
       }
     },
@@ -2325,7 +2286,7 @@
         "SEN"
       ],
       "minimalOrder": {
-        "amount": "906.0",
+        "amount": "3840.0",
         "unit": "asset"
       }
     },
@@ -2335,7 +2296,7 @@
         "SEN"
       ],
       "minimalOrder": {
-        "amount": "906.0",
+        "amount": "3840.0",
         "unit": "asset"
       }
     },
@@ -2345,7 +2306,7 @@
         "SEN"
       ],
       "minimalOrder": {
-        "amount": "906.0",
+        "amount": "3840.0",
         "unit": "asset"
       }
     },
@@ -2355,7 +2316,7 @@
         "NCA"
       ],
       "minimalOrder": {
-        "amount": "1352.0",
+        "amount": "2572.0",
         "unit": "asset"
       }
     },
@@ -2365,7 +2326,7 @@
         "NCA"
       ],
       "minimalOrder": {
-        "amount": "1352.0",
+        "amount": "2572.0",
         "unit": "asset"
       }
     },
@@ -2375,7 +2336,7 @@
         "NCA"
       ],
       "minimalOrder": {
-        "amount": "1352.0",
+        "amount": "2572.0",
         "unit": "asset"
       }
     },
@@ -2385,7 +2346,7 @@
         "CND"
       ],
       "minimalOrder": {
-        "amount": "498.0",
+        "amount": "606.0",
         "unit": "asset"
       }
     },
@@ -2395,7 +2356,7 @@
         "CND"
       ],
       "minimalOrder": {
-        "amount": "498.0",
+        "amount": "606.0",
         "unit": "asset"
       }
     },
@@ -2405,7 +2366,7 @@
         "CND"
       ],
       "minimalOrder": {
-        "amount": "498.0",
+        "amount": "606.0",
         "unit": "asset"
       }
     },
@@ -2415,7 +2376,7 @@
         "CTX"
       ],
       "minimalOrder": {
-        "amount": "30.0",
+        "amount": "48.0",
         "unit": "asset"
       }
     },
@@ -2425,7 +2386,7 @@
         "CTX"
       ],
       "minimalOrder": {
-        "amount": "30.0",
+        "amount": "48.0",
         "unit": "asset"
       }
     },
@@ -2435,7 +2396,7 @@
         "CTX"
       ],
       "minimalOrder": {
-        "amount": "30.0",
+        "amount": "48.0",
         "unit": "asset"
       }
     },
@@ -2445,7 +2406,7 @@
         "PAI"
       ],
       "minimalOrder": {
-        "amount": "20.0",
+        "amount": "82.0",
         "unit": "asset"
       }
     },
@@ -2455,7 +2416,7 @@
         "PAI"
       ],
       "minimalOrder": {
-        "amount": "20.0",
+        "amount": "82.0",
         "unit": "asset"
       }
     },
@@ -2465,7 +2426,7 @@
         "SEE"
       ],
       "minimalOrder": {
-        "amount": "3262.0",
+        "amount": "12382.0",
         "unit": "asset"
       }
     },
@@ -2475,7 +2436,7 @@
         "SEE"
       ],
       "minimalOrder": {
-        "amount": "3262.0",
+        "amount": "12382.0",
         "unit": "asset"
       }
     },
@@ -2485,7 +2446,7 @@
         "SEE"
       ],
       "minimalOrder": {
-        "amount": "3262.0",
+        "amount": "12382.0",
         "unit": "asset"
       }
     },
@@ -2495,7 +2456,7 @@
         "ESS"
       ],
       "minimalOrder": {
-        "amount": "798.0",
+        "amount": "3054.0",
         "unit": "asset"
       }
     },
@@ -2505,7 +2466,7 @@
         "ESS"
       ],
       "minimalOrder": {
-        "amount": "798.0",
+        "amount": "3054.0",
         "unit": "asset"
       }
     },
@@ -2515,7 +2476,7 @@
         "ESS"
       ],
       "minimalOrder": {
-        "amount": "798.0",
+        "amount": "3054.0",
         "unit": "asset"
       }
     },
@@ -2525,7 +2486,7 @@
         "ATM"
       ],
       "minimalOrder": {
-        "amount": "516.0",
+        "amount": "1842.0",
         "unit": "asset"
       }
     },
@@ -2535,7 +2496,7 @@
         "ATM"
       ],
       "minimalOrder": {
-        "amount": "516.0",
+        "amount": "1842.0",
         "unit": "asset"
       }
     },
@@ -2545,7 +2506,7 @@
         "ATM"
       ],
       "minimalOrder": {
-        "amount": "516.0",
+        "amount": "1842.0",
         "unit": "asset"
       }
     },
@@ -2555,7 +2516,7 @@
         "HOT"
       ],
       "minimalOrder": {
-        "amount": "562.0",
+        "amount": "1408.0",
         "unit": "asset"
       }
     },
@@ -2565,7 +2526,7 @@
         "HOT"
       ],
       "minimalOrder": {
-        "amount": "562.0",
+        "amount": "1408.0",
         "unit": "asset"
       }
     },
@@ -2575,7 +2536,7 @@
         "HOT"
       ],
       "minimalOrder": {
-        "amount": "562.0",
+        "amount": "1408.0",
         "unit": "asset"
       }
     },
@@ -2585,7 +2546,7 @@
         "DTA"
       ],
       "minimalOrder": {
-        "amount": "3480.0",
+        "amount": "5572.0",
         "unit": "asset"
       }
     },
@@ -2595,7 +2556,7 @@
         "DTA"
       ],
       "minimalOrder": {
-        "amount": "3480.0",
+        "amount": "5572.0",
         "unit": "asset"
       }
     },
@@ -2605,7 +2566,7 @@
         "DTA"
       ],
       "minimalOrder": {
-        "amount": "3480.0",
+        "amount": "5572.0",
         "unit": "asset"
       }
     },
@@ -2615,7 +2576,7 @@
         "IQX"
       ],
       "minimalOrder": {
-        "amount": "578.0",
+        "amount": "1798.0",
         "unit": "asset"
       }
     },
@@ -2625,7 +2586,7 @@
         "IQX"
       ],
       "minimalOrder": {
-        "amount": "578.0",
+        "amount": "1798.0",
         "unit": "asset"
       }
     },
@@ -2635,7 +2596,7 @@
         "IQX"
       ],
       "minimalOrder": {
-        "amount": "578.0",
+        "amount": "1798.0",
         "unit": "asset"
       }
     },
@@ -2645,7 +2606,7 @@
         "WPR"
       ],
       "minimalOrder": {
-        "amount": "370.0",
+        "amount": "590.0",
         "unit": "asset"
       }
     },
@@ -2655,7 +2616,7 @@
         "WPR"
       ],
       "minimalOrder": {
-        "amount": "370.0",
+        "amount": "590.0",
         "unit": "asset"
       }
     },
@@ -2665,7 +2626,7 @@
         "WPR"
       ],
       "minimalOrder": {
-        "amount": "370.0",
+        "amount": "590.0",
         "unit": "asset"
       }
     },
@@ -2675,7 +2636,7 @@
         "ZIL"
       ],
       "minimalOrder": {
-        "amount": "248.0",
+        "amount": "382.0",
         "unit": "asset"
       }
     },
@@ -2685,7 +2646,7 @@
         "ZIL"
       ],
       "minimalOrder": {
-        "amount": "248.0",
+        "amount": "382.0",
         "unit": "asset"
       }
     },
@@ -2695,7 +2656,7 @@
         "ZIL"
       ],
       "minimalOrder": {
-        "amount": "248.0",
+        "amount": "382.0",
         "unit": "asset"
       }
     },
@@ -2705,7 +2666,7 @@
         "BNT"
       ],
       "minimalOrder": {
-        "amount": "6.0",
+        "amount": "10.0",
         "unit": "asset"
       }
     },
@@ -2715,7 +2676,7 @@
         "BNT"
       ],
       "minimalOrder": {
-        "amount": "6.0",
+        "amount": "10.0",
         "unit": "asset"
       }
     },
@@ -2725,7 +2686,7 @@
         "BNT"
       ],
       "minimalOrder": {
-        "amount": "6.0",
+        "amount": "10.0",
         "unit": "asset"
       }
     },
@@ -2735,7 +2696,7 @@
         "ABS"
       ],
       "minimalOrder": {
-        "amount": "278.0",
+        "amount": "1136.0",
         "unit": "asset"
       }
     },
@@ -2745,7 +2706,7 @@
         "ABS"
       ],
       "minimalOrder": {
-        "amount": "278.0",
+        "amount": "1136.0",
         "unit": "asset"
       }
     },
@@ -2755,7 +2716,7 @@
         "XRA"
       ],
       "minimalOrder": {
-        "amount": "62.0",
+        "amount": "296.0",
         "unit": "asset"
       }
     },
@@ -2765,7 +2726,7 @@
         "XRA"
       ],
       "minimalOrder": {
-        "amount": "62.0",
+        "amount": "296.0",
         "unit": "asset"
       }
     },
@@ -2775,7 +2736,7 @@
         "MAN"
       ],
       "minimalOrder": {
-        "amount": "30.0",
+        "amount": "56.0",
         "unit": "asset"
       }
     },
@@ -2785,7 +2746,517 @@
         "MAN"
       ],
       "minimalOrder": {
+        "amount": "56.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "BBN"
+      ],
+      "minimalOrder": {
+        "amount": "1782.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "BBN"
+      ],
+      "minimalOrder": {
+        "amount": "1782.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "NIO"
+      ],
+      "minimalOrder": {
+        "amount": "676.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "NIO"
+      ],
+      "minimalOrder": {
+        "amount": "676.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "DGX"
+      ],
+      "minimalOrder": {
+        "amount": "0.2",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "DGX"
+      ],
+      "minimalOrder": {
+        "amount": "0.2",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "VET"
+      ],
+      "minimalOrder": {
+        "amount": "1286.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "VET"
+      ],
+      "minimalOrder": {
+        "amount": "1286.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "VET"
+      ],
+      "minimalOrder": {
+        "amount": "1286.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "UTN"
+      ],
+      "minimalOrder": {
+        "amount": "2698.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "UTN"
+      ],
+      "minimalOrder": {
+        "amount": "2698.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "TKN"
+      ],
+      "minimalOrder": {
+        "amount": "32.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "TKN"
+      ],
+      "minimalOrder": {
+        "amount": "32.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "GOT"
+      ],
+      "minimalOrder": {
+        "amount": "20.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "EUR",
+        "GOT"
+      ],
+      "minimalOrder": {
+        "amount": "20.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "GOT"
+      ],
+      "minimalOrder": {
+        "amount": "20.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "XTZ"
+      ],
+      "minimalOrder": {
+        "amount": "8.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "XTZ"
+      ],
+      "minimalOrder": {
+        "amount": "8.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "CNN"
+      ],
+      "minimalOrder": {
+        "amount": "34370.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "CNN"
+      ],
+      "minimalOrder": {
+        "amount": "34370.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "BOX"
+      ],
+      "minimalOrder": {
+        "amount": "1252.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "BOX"
+      ],
+      "minimalOrder": {
+        "amount": "1252.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "EUR",
+        "TRX"
+      ],
+      "minimalOrder": {
+        "amount": "526.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "GBP",
+        "TRX"
+      ],
+      "minimalOrder": {
+        "amount": "526.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "JPY",
+        "TRX"
+      ],
+      "minimalOrder": {
+        "amount": "526.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "MGO"
+      ],
+      "minimalOrder": {
         "amount": "30.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "MGO"
+      ],
+      "minimalOrder": {
+        "amount": "30.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "RTE"
+      ],
+      "minimalOrder": {
+        "amount": "2950.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "RTE"
+      ],
+      "minimalOrder": {
+        "amount": "2950.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "YGG"
+      ],
+      "minimalOrder": {
+        "amount": "11104.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "YGG"
+      ],
+      "minimalOrder": {
+        "amount": "11104.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "MLN"
+      ],
+      "minimalOrder": {
+        "amount": "2.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "MLN"
+      ],
+      "minimalOrder": {
+        "amount": "2.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "WTC"
+      ],
+      "minimalOrder": {
+        "amount": "4.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "WTC"
+      ],
+      "minimalOrder": {
+        "amount": "4.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "CSX"
+      ],
+      "minimalOrder": {
+        "amount": "72.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "CSX"
+      ],
+      "minimalOrder": {
+        "amount": "72.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "OMN"
+      ],
+      "minimalOrder": {
+        "amount": "2.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "OMN"
+      ],
+      "minimalOrder": {
+        "amount": "2.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "INT"
+      ],
+      "minimalOrder": {
+        "amount": "352.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "INT"
+      ],
+      "minimalOrder": {
+        "amount": "352.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "DRN"
+      ],
+      "minimalOrder": {
+        "amount": "62.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "DRN"
+      ],
+      "minimalOrder": {
+        "amount": "62.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "PNK"
+      ],
+      "minimalOrder": {
+        "amount": "1394.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "ETH",
+        "PNK"
+      ],
+      "minimalOrder": {
+        "amount": "1394.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "DGB"
+      ],
+      "minimalOrder": {
+        "amount": "566.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "DGB"
+      ],
+      "minimalOrder": {
+        "amount": "566.0",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "BSV"
+      ],
+      "minimalOrder": {
+        "amount": "0.1",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "BSV"
+      ],
+      "minimalOrder": {
+        "amount": "0.1",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "USD",
+        "BAB"
+      ],
+      "minimalOrder": {
+        "amount": "0.04",
+        "unit": "asset"
+      }
+    },
+    {
+      "pair": [
+        "BTC",
+        "BAB"
+      ],
+      "minimalOrder": {
+        "amount": "0.04",
         "unit": "asset"
       }
     }

--- a/exchange/wrappers/poloniex.js
+++ b/exchange/wrappers/poloniex.js
@@ -62,6 +62,20 @@ const includes = (str, list) => {
   return _.some(list, item => str.includes(item));
 }
 
+Trader.prototype.outbidPrice = function(price, isUp) {
+  let newPrice;
+
+  const tickSize = 0.00000001;
+
+  if(isUp) {
+    newPrice = price + 0.00000001;
+  } else {
+    newPrice = price - tickSize;
+  }
+
+  return this.roundPrice(newPrice);
+}
+
 Trader.prototype.processResponse = function(next, fn, payload) {
   // TODO: in very rare cases the callback is
   // called twice (first on ETIMEDOUT later

--- a/importers/exchanges/kraken.js
+++ b/importers/exchanges/kraken.js
@@ -35,6 +35,11 @@ var fetch = () => {
 }
 
 var handleFetch = (err, trades) => {
+    if(!err && !trades.length) {
+        console.log('no trades');
+        err = 'No trades';
+    }
+
     if (err) {
         log.error(`There was an error importing from Kraken ${err}`);
         fetcher.emit('done');

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.19",
         "negotiator": "0.6.1"
       }
     },
@@ -32,10 +32,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ansi-regex": {
@@ -63,37 +63,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "asap": {
@@ -106,7 +77,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -125,7 +96,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
       "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -166,7 +137,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "bitfinex-api-node": {
@@ -174,11 +145,11 @@
       "resolved": "https://registry.npmjs.org/bitfinex-api-node/-/bitfinex-api-node-1.2.1.tgz",
       "integrity": "sha512-pG4BMCD7T/R1vkLhLdHPim4Lbfbkdyt/yTaJ+A48vrzGsQO7MwxIRRs6rEx1Acm/vpsUyksbOaQyladh2T8Whw==",
       "requires": {
-        "debug": "^2.2.0",
-        "lodash": "^4.17.4",
-        "request": "^2.67.0",
-        "request-promise": "^4.2.0",
-        "ws": "^3.0.0"
+        "debug": "2.6.9",
+        "lodash": "4.17.10",
+        "request": "2.87.0",
+        "request-promise": "4.2.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "lodash": {
@@ -191,9 +162,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           }
         }
       }
@@ -208,7 +179,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -234,12 +205,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chalk": {
@@ -247,11 +218,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "check-error": {
@@ -261,9 +232,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "co": {
       "version": "4.6.0",
@@ -275,10 +246,10 @@
       "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.2.0.tgz",
       "integrity": "sha512-sX/LQ7LqUhgyaxzbe7IqwPeTr2yfpfUIQ/dgpKo6ZI4y4lpQA0YxAomWIY+7I7rHWcG02PG+OuPREzMW/5tszQ==",
       "requires": {
-        "inflation": "^2.0.0",
-        "qs": "^6.4.0",
-        "raw-body": "^2.2.0",
-        "type-is": "^1.6.14"
+        "inflation": "2.0.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
       }
     },
     "co-from-stream": {
@@ -318,7 +289,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -331,8 +302,8 @@
       "resolved": "https://registry.npmjs.org/composition/-/composition-2.3.0.tgz",
       "integrity": "sha1-dCgFN0yrVQxSCjNmL1pzLgII1vI=",
       "requires": {
-        "any-promise": "^1.1.0",
-        "co": "^4.0.2"
+        "any-promise": "1.3.0",
+        "co": "4.6.0"
       }
     },
     "concat-map": {
@@ -360,8 +331,8 @@
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
       "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
       "requires": {
-        "depd": "~1.1.1",
-        "keygrip": "~1.0.2"
+        "depd": "1.1.2",
+        "keygrip": "1.0.2"
       }
     },
     "copy-to": {
@@ -379,7 +350,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -396,7 +367,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-equal": {
@@ -446,8 +417,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -501,8 +472,8 @@
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
       }
     },
     "forever-agent": {
@@ -515,9 +486,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.19"
       }
     },
     "fresh": {
@@ -530,7 +501,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.5"
       }
     },
     "fs.realpath": {
@@ -543,14 +514,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       }
     },
     "gekko": {
@@ -569,7 +540,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -577,12 +548,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "growl": {
@@ -601,8 +572,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -610,7 +581,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -635,8 +606,8 @@
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
       "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
       "requires": {
-        "deep-equal": "~1.0.1",
-        "http-errors": "~1.6.1"
+        "deep-equal": "1.0.1",
+        "http-errors": "1.6.3"
       },
       "dependencies": {
         "http-errors": {
@@ -644,10 +615,10 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           }
         }
       }
@@ -657,10 +628,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.0.tgz",
       "integrity": "sha512-hz3BtSHB7Z6dNWzYc+gUbWqG4dIpJedwwOhe1cvGUq5tGmcTTIRkPiAbyh/JlZx+ksSJyGJlgcHo5jGahiXnKw==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "1.5.0",
         "toidentifier": "1.0.0"
       }
     },
@@ -669,9 +640,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "humanize-duration": {
@@ -689,7 +660,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore-walk": {
@@ -697,7 +668,7 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "inflation": {
@@ -710,8 +681,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -729,8 +700,8 @@
       "resolved": "https://registry.npmjs.org/ipcee/-/ipcee-1.0.6.tgz",
       "integrity": "sha1-PI3I5nh9gdIkyY6POcvvCeBV5tQ=",
       "requires": {
-        "debug": "^2.2.0",
-        "eventemitter2": "^2.0.0"
+        "debug": "2.6.9",
+        "eventemitter2": "2.2.2"
       }
     },
     "is-fullwidth-code-point": {
@@ -738,7 +709,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-object": {
@@ -815,29 +786,29 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-1.6.0.tgz",
       "integrity": "sha512-tW7xJGDG4LyhFUTtzIyqJCIaJIFgkre1tJPGNe/moRKOIU0L9vEIhW5z7iMX7FJTkYm45urdbPOGBp0VlWF03w==",
       "requires": {
-        "accepts": "^1.2.2",
-        "co": "^4.4.0",
-        "composition": "^2.1.1",
-        "content-disposition": "~0.5.0",
-        "content-type": "^1.0.0",
-        "cookies": "~0.7.0",
-        "debug": "*",
-        "delegates": "^1.0.0",
-        "destroy": "^1.0.3",
-        "error-inject": "~1.0.0",
-        "escape-html": "~1.0.1",
-        "fresh": "^0.5.2",
-        "http-assert": "^1.1.0",
-        "http-errors": "^1.2.8",
-        "koa-compose": "^2.3.0",
-        "koa-is-json": "^1.0.0",
-        "mime-types": "^2.0.7",
-        "on-finished": "^2.1.0",
+        "accepts": "1.3.5",
+        "co": "4.6.0",
+        "composition": "2.3.0",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookies": "0.7.1",
+        "debug": "2.6.9",
+        "delegates": "1.0.0",
+        "destroy": "1.0.4",
+        "error-inject": "1.0.0",
+        "escape-html": "1.0.3",
+        "fresh": "0.5.2",
+        "http-assert": "1.3.0",
+        "http-errors": "1.7.0",
+        "koa-compose": "2.5.1",
+        "koa-is-json": "1.0.0",
+        "mime-types": "2.1.19",
+        "on-finished": "2.3.0",
         "only": "0.0.2",
-        "parseurl": "^1.3.0",
-        "statuses": "^1.2.0",
-        "type-is": "^1.5.5",
-        "vary": "^1.0.0"
+        "parseurl": "1.3.2",
+        "statuses": "1.5.0",
+        "type-is": "1.6.16",
+        "vary": "1.1.2"
       }
     },
     "koa-bodyparser": {
@@ -845,8 +816,8 @@
       "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-2.5.0.tgz",
       "integrity": "sha1-PrckP0eZii53LbBfbcTg9PPMvfA=",
       "requires": {
-        "co-body": "^5.1.0",
-        "copy-to": "^2.0.1"
+        "co-body": "5.2.0",
+        "copy-to": "2.0.1"
       }
     },
     "koa-compose": {
@@ -869,10 +840,10 @@
       "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-1.3.1.tgz",
       "integrity": "sha1-rT9fIZOzM0Mo8+uZphj0sEvui9U=",
       "requires": {
-        "bytes": "1",
-        "chalk": "^1.1.3",
+        "bytes": "1.0.0",
+        "chalk": "1.1.3",
         "humanize-number": "0.0.2",
-        "passthrough-counter": "^1.0.0"
+        "passthrough-counter": "1.0.0"
       },
       "dependencies": {
         "bytes": {
@@ -887,11 +858,11 @@
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-5.4.2.tgz",
       "integrity": "sha1-Tb26fnFZU9VobAO3w/29IUYx+HA=",
       "requires": {
-        "co": "^4.6.0",
-        "debug": "^2.2.0",
-        "http-errors": "^1.3.1",
-        "methods": "^1.0.1",
-        "path-to-regexp": "^1.1.1"
+        "co": "4.6.0",
+        "debug": "2.6.9",
+        "http-errors": "1.7.0",
+        "methods": "1.1.2",
+        "path-to-regexp": "1.7.0"
       }
     },
     "koa-send": {
@@ -899,10 +870,10 @@
       "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-3.3.0.tgz",
       "integrity": "sha1-WkriRVZGgMbs9geeknX6UXOoYdw=",
       "requires": {
-        "co": "^4.6.0",
-        "debug": "^2.6.0",
-        "mz": "^2.3.1",
-        "resolve-path": "^1.3.1"
+        "co": "4.6.0",
+        "debug": "2.6.9",
+        "mz": "2.7.0",
+        "resolve-path": "1.4.0"
       }
     },
     "koa-static": {
@@ -910,8 +881,8 @@
       "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-2.1.0.tgz",
       "integrity": "sha1-z+KS6n2ryWqnI+SkiGFcxlrnQWk=",
       "requires": {
-        "debug": "^2.6.0",
-        "koa-send": "^3.3.0"
+        "debug": "2.6.9",
+        "koa-send": "3.3.0"
       }
     },
     "lodash": {
@@ -957,7 +928,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "requires": {
-        "mime-db": "~1.35.0"
+        "mime-db": "1.35.0"
       }
     },
     "minimatch": {
@@ -965,7 +936,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -974,20 +945,20 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
-      "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
       }
     },
     "minizlib": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
+      "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.5"
       }
     },
     "mkdirp": {
@@ -1038,7 +1009,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1069,24 +1040,24 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       }
     },
     "nan": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "needle": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
-      "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.23",
+        "sax": "1.2.4"
       }
     },
     "negotiator": {
@@ -1100,11 +1071,11 @@
       "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.7.1",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
       }
     },
     "node-pre-gyp": {
@@ -1112,16 +1083,16 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
       "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
       "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.2.4",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.1.12",
+        "npmlog": "4.1.2",
+        "rc": "1.2.8",
+        "rimraf": "2.6.2",
+        "semver": "5.4.1",
+        "tar": "4.4.8"
       }
     },
     "nodegit-promise": {
@@ -1129,7 +1100,7 @@
       "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
       "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "nopt": {
@@ -1137,22 +1108,22 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
       }
     },
     "npm-bundled": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
     },
     "npm-packlist": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
-      "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
+      "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
       "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.5"
       }
     },
     "npmlog": {
@@ -1160,10 +1131,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -1194,7 +1165,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "only": {
@@ -1207,18 +1178,18 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
       }
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -1226,8 +1197,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "parseurl": {
@@ -1274,7 +1245,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "process-nextick-args": {
@@ -1287,8 +1258,8 @@
       "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.5.0.tgz",
       "integrity": "sha512-GR2E4qgCoKFTprhULqP2OP3bl8kHo16XtnqtkHH6be7tPW1yL6rXd15nl3oV2sLTFv1+j6tqoF69VVpFtJ/j+A==",
       "requires": {
-        "nodegit-promise": "^4.0.0",
-        "object-assign": "^4.1.1"
+        "nodegit-promise": "4.0.0",
+        "object-assign": "4.1.1"
       }
     },
     "prompt-lite": {
@@ -1296,10 +1267,10 @@
       "resolved": "https://registry.npmjs.org/prompt-lite/-/prompt-lite-0.1.1.tgz",
       "integrity": "sha1-+oSPgboTnn0/Mhdz3a/JPTKFfHU=",
       "requires": {
-        "async": "~0.1.22",
-        "colors": "0.6.x",
-        "read": "1.0.x",
-        "revalidator": "0.1.x"
+        "async": "0.1.22",
+        "colors": "0.6.2",
+        "read": "1.0.7",
+        "revalidator": "0.1.8"
       },
       "dependencies": {
         "async": {
@@ -1315,9 +1286,9 @@
       "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
       "dev": true,
       "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.1.7"
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
       }
     },
     "punycode": {
@@ -1346,10 +1317,10 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           }
         }
       }
@@ -1359,15 +1330,15 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -1377,7 +1348,28 @@
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
       }
     },
     "relieve": {
@@ -1385,11 +1377,11 @@
       "resolved": "https://registry.npmjs.org/relieve/-/relieve-2.2.3.tgz",
       "integrity": "sha512-h3i6n981nqh1K0TxK+TKaFf/Kf2MUgJHhEYUeKNj+by0uoxne/ldYsNKB2HA9fBX77v+uZE+pfxoRa9ZxuBgIA==",
       "requires": {
-        "bluebird": "^3.4.0",
-        "debug": "^2.2.0",
-        "eventemitter2": "^2.0.0",
-        "ipcee": "^1.0.6",
-        "uuid": "^2.0.2"
+        "bluebird": "3.5.1",
+        "debug": "2.6.9",
+        "eventemitter2": "2.2.2",
+        "ipcee": "1.0.6",
+        "uuid": "2.0.3"
       },
       "dependencies": {
         "uuid": {
@@ -1404,26 +1396,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.19",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "request-promise": {
@@ -1431,10 +1423,10 @@
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
       "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
       "requires": {
-        "bluebird": "^3.5.0",
+        "bluebird": "3.5.1",
         "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
       }
     },
     "request-promise-core": {
@@ -1442,7 +1434,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -1463,7 +1455,7 @@
       "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
       "integrity": "sha1-xL2p9e+y/OZSR4c6s2u02DT+Fvc=",
       "requires": {
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "path-is-absolute": "1.0.1"
       },
       "dependencies": {
@@ -1472,10 +1464,10 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
+            "statuses": "1.5.0"
           }
         }
       }
@@ -1495,7 +1487,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "safe-buffer": {
@@ -1545,13 +1537,13 @@
       "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.7.1",
+        "nise": "1.4.2",
+        "supports-color": "5.4.0",
+        "type-detect": "4.0.8"
       },
       "dependencies": {
         "supports-color": {
@@ -1560,19 +1552,19 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
     },
     "sqlite3": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.2.tgz",
-      "integrity": "sha512-51ferIRwYOhzUEtogqOa/y9supADlAht98bF/gbIi6WkzRJX6Yioldxbzj1MV4yV+LgdKD/kkHwFTeFXOG4htA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.4.tgz",
+      "integrity": "sha512-CO8vZMyUXBPC+E3iXOCc7Tz2pAdq5BWfLcQmOokCOZW5S5sZ/paijiPOCdvzpdP83RroWHYa5xYlVqCxSqpnQg==",
       "requires": {
-        "nan": "~2.10.0",
-        "node-pre-gyp": "^0.10.3",
-        "request": "^2.87.0"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.3",
+        "request": "2.87.0"
       }
     },
     "sshpk": {
@@ -1580,15 +1572,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stats-lite": {
@@ -1596,7 +1588,7 @@
       "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.1.1.tgz",
       "integrity": "sha512-5QkxGCWGMbeQ+PXqI2N7ES6kW4IimvbMQBCKvZbekaEpf3InckVHiIXdCJbZsKUjLE7a3jha2cTEJqtOGGcVMw==",
       "requires": {
-        "isnumber": "~1.0.0"
+        "isnumber": "1.0.0"
       }
     },
     "statuses": {
@@ -1614,9 +1606,17 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -1624,7 +1624,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-json-comments": {
@@ -1638,17 +1638,17 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tar": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
-      "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "chownr": "1.1.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.5",
+        "minizlib": "1.1.1",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.3"
       }
     },
     "text-encoding": {
@@ -1662,7 +1662,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "requires": {
-        "any-promise": "^1.0.0"
+        "any-promise": "1.3.0"
       }
     },
     "thenify-all": {
@@ -1670,7 +1670,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "requires": {
-        "thenify": ">= 3.1.0 < 4"
+        "thenify": "3.3.0"
       }
     },
     "thunkify": {
@@ -1698,7 +1698,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tunnel-agent": {
@@ -1706,7 +1706,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -1727,7 +1727,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.19"
       }
     },
     "ultron": {
@@ -1760,9 +1760,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "wide-align": {
@@ -1770,7 +1770,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
       }
     },
     "wrappy": {
@@ -1783,13 +1783,13 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
       "integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "yallist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "relieve": "^2.1.3",
     "retry": "^0.10.1",
     "semver": "5.4.1",
-    "sqlite3": "^4.0.0",
+    "sqlite3": "^4.0.4",
     "stats-lite": "^2.0.4",
     "tiny-promisify": "^0.1.1",
     "toml": "^2.3.0",

--- a/plugins/paperTrader/paperTrader.js
+++ b/plugins/paperTrader/paperTrader.js
@@ -38,6 +38,10 @@ const PaperTrader = function() {
 
   this.propogatedTrades = 0;
   this.propogatedTriggers = 0;
+
+  this.warmupCompleted = false;
+
+  this.warmupCandle;
 }
 
 PaperTrader.prototype.relayPortfolioChange = function() {
@@ -245,7 +249,17 @@ PaperTrader.prototype.onStopTrigger = function() {
   delete this.activeStopTrigger;
 }
 
+PaperTrader.prototype.processStratWarmupCompleted = function() {
+  this.warmupCompleted = true;
+  this.processCandle(this.warmupCandle, _.noop);
+}
+
 PaperTrader.prototype.processCandle = function(candle, done) {
+  if(!this.warmupCompleted) {
+    this.warmupCandle = candle;
+    return done();
+  }
+
   this.price = candle.close;
   this.candle = candle;
 

--- a/plugins/tradingAdvisor/tradingAdvisor.js
+++ b/plugins/tradingAdvisor/tradingAdvisor.js
@@ -60,11 +60,11 @@ Actor.prototype.setupStrategy = function() {
 
   this.strategy = new WrappedStrategy(stratSettings);
   this.strategy
-    .on('advice', this.relayAdvice)
     .on(
       'stratWarmupCompleted',
       e => this.deferredEmit('stratWarmupCompleted', e)
     )
+    .on('advice', this.relayAdvice)
     .on(
       'stratUpdate',
       e => this.deferredEmit('stratUpdate', e)


### PR DESCRIPTION
Small tweaks from upstream Gekko Plus.

Biggest change is ea0f5cd: with this change the two core components of a simulation (paper trader & performance analyzer) ignore all market data until the warmup is complete. This way the backtest more accurately compares the market with the time the strategy was actually running (as opposed to simply warming up).