### PR TITLE
[docs] update documented required node versio, fix #2644

### DIFF
--- a/docs/installation/installing_gekko.md
+++ b/docs/installation/installing_gekko.md
@@ -20,7 +20,7 @@ To get Gekko running you need to do the following:
 
 ## Installing nodejs
 
-Gekko requires [nodejs](https://nodejs.org/en/) to be installed. Go ahead and install this if it's not already (Gekko requires at least version 6). We advice to download the current LTS.
+Gekko requires [nodejs](https://nodejs.org/en/) to be installed. Go ahead and install this if it's not already (Gekko requires at least version 8.11.2). We advice to download the current LTS.
 
 ## Installing git
 


### PR DESCRIPTION
Gekko requires at least 8.11.2, document as such.