### PR TITLE
Fix install issue with sqlite3 in Raspbian 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "relieve": "^2.1.3",
     "retry": "^0.10.1",
     "semver": "5.4.1",
-    "sqlite3": "^4.0.4",
+    "sqlite3": "^4.0.6",
     "stats-lite": "^2.0.4",
     "tiny-promisify": "^0.1.1",
     "toml": "^2.3.0",


### PR DESCRIPTION
node-sqlite3 4.0.6 fixed a build break that manifested in Raspbian 9

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Can't install gekko in Raspbian 9 because of a  build break with sqlite3 


* **What is the new behavior (if this is a feature change)?**
Gekko installs successfully and sqlite3 compiles fine.


* **Other information**:
