### PR TITLE
Rejected trades are now recreated

### DIFF
--- a/exchange/orders/sticky.js
+++ b/exchange/orders/sticky.js
@@ -332,6 +332,13 @@ class StickyOrder extends BaseOrder {
       return false;
     }
 
+    if (error.message == 'post only error') {
+      this.price = this.calculatePrice(this.data.ticker);
+      console.log('Reissue trade order at', this.price);
+      this.createOrder();
+      return true;
+    }
+
     console.log(new Date, '[sticky order] FATAL ERROR', error.message);
     console.log(new Date, error);
     this.status = states.ERROR;

--- a/exchange/wrappers/gdax.js
+++ b/exchange/wrappers/gdax.js
@@ -217,6 +217,10 @@ Trader.prototype.checkOrder = function(order, callback) {
     } if (status === 'done' || status === 'settled') {
       return callback(undefined, { executed: true, open: false });
     } else if (status === 'rejected') {
+      if (data.reject_reason == 'post only' ) {
+          console.log ('post only error');
+          return callback(new Error('post only error'));
+      }
       return callback(undefined, { executed: false, open: false });
     } else if(status === 'open' || status === 'active') {
       return callback(undefined, { executed: false, open: true, filledAmount: parseFloat(data.filled_size) });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When a trade is rejected in Coinbase Pro because the price moved after Gekko sent the trade to the exchange, a new trade isn't recreated (can't retry the trade as the exchanged deleted it). Gekko holds asset that wasn't sold until the user intervenes by manually selling (and restarting Gekko). Rejected buy orders also require user intervention as Gekko thinks it bought the asset and won't respond to a new buy order until a sell order is issued.

* **What is the new behavior (if this is a feature change)?**

Gekko will note the error in terminal, recalculate the price based on ticker info, and recreate the trade using new price information. 

* **Other information**:
