### PR TITLE
Allow turning on SSL in Docker

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 HOST=localhost
 PORT=3000
+USE_SSL=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
      - HOST
      - PORT
+     - USE_SSL
     ports: # you can comment this out when using the nginx frontend
       - "${PORT}:${PORT}"
 ## optionally set nginx vars if you wish to frontend it with nginx

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,4 +3,7 @@
 sed -i 's/127.0.0.1/0.0.0.0/g' /usr/src/app/web/vue/dist/UIconfig.js
 sed -i 's/localhost/'${HOST}'/g' /usr/src/app/web/vue/dist/UIconfig.js
 sed -i 's/3000/'${PORT}'/g' /usr/src/app/web/vue/dist/UIconfig.js
+if [[ "${USE_SSL:-0}" == "1" ]] ; then
+    sed -i 's/ssl: false/ssl: true/g' /usr/src/app/web/vue/dist/UIconfig.js
+fi
 exec node gekko "$@"

--- a/docs/installation/installing_gekko_using_docker.md
+++ b/docs/installation/installing_gekko_using_docker.md
@@ -20,4 +20,6 @@ $ HOST=mydomain.com PORT=3001 docker-compose up -d
 
 You can now find your gekko instance running on `mydomain.com:3001`.
 
+If running behind an SSL-terminating proxy, make sure to set `USE_SSL=1` to tell the Gekko to use the HTTPS and WSS protocols instead of the default HTTP and WS protocols.
+
 To see logs: `docker logs -f gekko_gekko_1`. View which dockers are running by executing `docker ps`.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds a feature (`USE_SSL` environment variable to control the Docker entrypoint) and documentation for it.

* **What is the current behavior?** (You can also link to an open issue here)

Currently there's no way to tell the docker entrypoint script to use SSL, so the Docker always produces a frontend that wants to talk to a "ws://" endpoint. This doesn't work behind an SSL-terminating reverse proxy.

* **What is the new behavior (if this is a feature change)?**

Now you can set `USE_SSL=1` along with the `HOST` and `PORT` variables, to tell the Docker to serve a frontend that expects to be behind HTTPS.

* **Other information**:
