### PR TITLE
FIX Binance "Error -2011: Unknown order sent" for CANCEL_REJECTED

### DIFF
--- a/exchange/wrappers/binance.js
+++ b/exchange/wrappers/binance.js
@@ -78,6 +78,7 @@ const recoverableErrors = [
   'CONNREFUSED',
   'NOTFOUND',
   'Error -1021',
+  'Error -2011',
   'Response code 429',
   'Response code 5',
   'Response code 403',
@@ -110,8 +111,8 @@ Trader.prototype.handleResponse = function(funcName, callback) {
         error.notFatal = true;
       }
 
-      if(funcName === 'cancelOrder' && error.message.includes('UNKNOWN_ORDER')) {
-        console.log(new Date, 'cancelOrder', 'UNKNOWN_ORDER');
+      if(funcName === 'cancelOrder' && error.message.includes('Error -2011')) {
+        console.log(new Date, 'cancelOrder', 'Error -2011');
         // order got filled in full before it could be
         // cancelled, meaning it was NOT cancelled.
         return callback(false, {filled: true});


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix "Error -2011: Unknown order sent" when gekko wants to cancel an order, but it is filled at the same time on Binance.


* **What is the current behavior?** (You can also link to an open issue here)
UI don't reflect order
See : Binance live trading error: Unknown order sent #2762 

* **Other information**:
I'm still being tested but it seems to be working fine for now.

I did not find a reference to the error code "UNKNOWN_ORDER" in the binance API, so I assume that this error code has been replaced by "Error -2011" with the message "Unknown order sent"  according to [this page](https://github.com/binance-exchange/binance-official-api-docs/blob/master/errors.md).


