### PR TITLE
strategies can report custom backtest results

### DIFF
--- a/core/gekkoStream.js
+++ b/core/gekkoStream.js
@@ -101,12 +101,12 @@ Gekko.prototype.finalize = function() {
   tradingMethod.finish(this.shutdown.bind(this));
 }
 
-Gekko.prototype.shutdown = function() {
+Gekko.prototype.shutdown = function(stratResults) {
   this.end();
   async.eachSeries(
     this.plugins,
     function(c, callback) {
-      if (c.finalize) c.finalize(callback);
+      if (c.finalize) c.finalize(callback, stratResults);
       else callback();
     },
     () => {

--- a/plugins/performanceAnalyzer/logger.js
+++ b/plugins/performanceAnalyzer/logger.js
@@ -83,6 +83,14 @@ if(mode === 'backtest') {
   }
 
   Logger.prototype.finalize = function(report) {
+    if (report.stratResults) {
+      log.info();
+      log.info('STRATEGY RESULTS:');
+      log.info(JSON.stringify(report.stratResults));
+    }
+    if (!report.trades) {
+      return;
+    }
 
     log.info();
     log.info('(ROUNDTRIP) REPORT:');

--- a/plugins/performanceAnalyzer/performanceAnalyzer.js
+++ b/plugins/performanceAnalyzer/performanceAnalyzer.js
@@ -231,17 +231,29 @@ PerformanceAnalyzer.prototype.calculateReportStatistics = function() {
   return report;
 }
 
-PerformanceAnalyzer.prototype.finalize = function(done) {
+PerformanceAnalyzer.prototype.finalize = function(done, stratResults) {
   if(!this.trades) {
+    if (stratResults) {
+      this.logReport({stratResults});
+    }
     return done();
   }
 
   const report = this.calculateReportStatistics();
   if(report) {
-    this.logger.finalize(report);
-    this.emit('performanceReport', report);
+    if (stratResults) {
+      report.stratResults = stratResults;
+    }
+    this.logReport(report);
+  } else if (stratResults) {
+    this.logReport({stratResults});
   }
   done();
+}
+
+PerformanceAnalyzer.prototype.logReport = function (report) {
+  this.logger.finalize(report);
+  this.emit('performanceReport', report);
 }
 
 

--- a/plugins/tradingAdvisor/baseTradingMethod.js
+++ b/plugins/tradingAdvisor/baseTradingMethod.js
@@ -317,13 +317,13 @@ Base.prototype.finish = function(done) {
   // to be sure we only stop after all candles are
   // processed.
   if(!this.asyncTick) {
-    this.end();
-    return done();
+    let stratResults = this.end();
+    return done(stratResults);
   }
 
   if(this.age === this.processedTicks) {
-    this.end();
-    return done();
+    let stratResults = this.end();
+    return done(stratResults);
   }
 
   // we are not done, register cb


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature.

* **What is the new behavior (if this is a feature change)?**
Now strategies can report custom results, in backtests.  If you want to keep track of whatever custom metrics you're interested in, beyond the stuff that gekko reports after a backtest, then there's a hook for that now.  Your strategy's end() function can now return a value, and that value will be printed out in the backtest logs and returned to the caller through the REST api.
