### PR TITLE
include module exports in instructions

### DIFF
--- a/docs/installation/configuring_gekko_on_a_server.md
+++ b/docs/installation/configuring_gekko_on_a_server.md
@@ -65,7 +65,7 @@ The following assumes you configured a reverse proxy, if you did not simply foll
             path: '/' // change this if you are serving from something like `example.com/gekko`
         },
         adapter: 'sqlite'
-    }
+    };
     
     if(typeof window === 'undefined')
         module.exports = CONFIG;

--- a/docs/installation/configuring_gekko_on_a_server.md
+++ b/docs/installation/configuring_gekko_on_a_server.md
@@ -24,6 +24,7 @@ Edit the uiconfig file like so:
         api: {
             host: '0.0.0.0',
             port: 3000,
+            timeout: 120000 // 2 minutes
         },
         ui: {
             ssl: false,
@@ -33,7 +34,12 @@ Edit the uiconfig file like so:
         },
         adapter: 'sqlite'
 
-    }
+    };
+    
+    if(typeof window === 'undefined')
+        module.exports = CONFIG;
+    else
+        window.CONFIG = CONFIG;
 
 You can now access the Gekko UI by going to `http://x.x.x.x:3000` in a browser (change `x.x.x.x` with the IP of the machine that will run Gekko).
 
@@ -50,6 +56,7 @@ The following assumes you configured a reverse proxy, if you did not simply foll
         api: {
             host: '127.0.0.1',
             port: 3000,
+            timeout: 120000 // 2 minutes
         },
         ui: {
             ssl: true,
@@ -59,6 +66,11 @@ The following assumes you configured a reverse proxy, if you did not simply foll
         },
         adapter: 'sqlite'
     }
+    
+    if(typeof window === 'undefined')
+        module.exports = CONFIG;
+    else
+        window.CONFIG = CONFIG;
 
 
 ## Configuring NGINX as a reverse proxy


### PR DESCRIPTION
in issues https://github.com/askmike/gekko/issues/2493 and https://github.com/askmike/gekko/issues/2576, users saw an error (`TypeError: Cannot read property 'timeout' of undefined`) that is not easy to understand because they had edited their uiconfig files according to the instructions here, which omit the export. This change is to include an example of a complete uiconfig file to reduce confusion by users who copy and paste the example code over the entire contents of their existing uiconfig.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - docs update

* **What is the current behavior?** (You can also link to an open issue here)
  - users copy and paste the example code over the complete contents of uiconfig, causing the module export to be omitted.
    - https://github.com/askmike/gekko/issues/2493
    - https://github.com/askmike/gekko/issues/2576

* **What is the new behavior (if this is a feature change)?**
  - the user is presented with a complete example of uiconfig, preventing errors of omission.

* **Other information**:
none